### PR TITLE
feat: 保護対象ルートにJWT認証ミドルウェアを適用

### DIFF
--- a/backend/infrastructure/web/api_integration_test.go
+++ b/backend/infrastructure/web/api_integration_test.go
@@ -258,6 +258,7 @@ func setupTestServer() (*echo.Echo, *MockManageFinancialDataUseCase, *MockCalcul
 		GoalRepo:              nil,
 		CalculationService:    nil,
 		RecommendationService: nil,
+		SkipAuth:              true, // テスト用に認証をスキップ
 	}
 
 	// Setup routes

--- a/backend/infrastructure/web/routes.go
+++ b/backend/infrastructure/web/routes.go
@@ -45,17 +45,23 @@ func SetupRoutes(e *echo.Echo, controllers *Controllers, deps *ServerDependencie
 	// 認証エンドポイント（認証不要）
 	setupAuthRoutes(api, controllers.Auth)
 
+	// 認証が必要なエンドポイント用グループ
+	protected := api.Group("")
+	if authMiddleware := deps.JWTAuthMiddlewareFunc(); authMiddleware != nil {
+		protected.Use(authMiddleware)
+	}
+
 	// 財務データ管理エンドポイント
-	setupFinancialDataRoutes(api, controllers.FinancialData)
+	setupFinancialDataRoutes(protected, controllers.FinancialData)
 
 	// 計算エンドポイント
-	setupCalculationRoutes(api, controllers.Calculations)
+	setupCalculationRoutes(protected, controllers.Calculations)
 
 	// 目標管理エンドポイント
-	setupGoalRoutes(api, controllers.Goals)
+	setupGoalRoutes(protected, controllers.Goals)
 
 	// レポート生成エンドポイント
-	setupReportRoutes(api, controllers.Reports)
+	setupReportRoutes(protected, controllers.Reports)
 }
 
 // setupAuthRoutes sets up authentication routes

--- a/backend/infrastructure/web/routes_test.go
+++ b/backend/infrastructure/web/routes_test.go
@@ -52,6 +52,7 @@ func TestSetupRoutes(t *testing.T) {
 		GoalRepo:              nil,
 		CalculationService:    nil,
 		RecommendationService: nil,
+		SkipAuth:              true, // テスト用に認証をスキップ
 	}
 
 	// This should not panic


### PR DESCRIPTION
- ServerDependenciesにAuthUseCaseとSkipAuthフラグを追加
- JWTAuthMiddlewareFunc()メソッドを追加
- routes.goでprotectedグループを作成し、認証が必要なエンドポイントを保護
  - /api/financial-data/*
  - /api/calculations/*
  - /api/goals/*
  - /api/reports/*
- /api/auth/* (ログイン/登録)は認証不要のまま
- テストファイルにSkipAuth: true を設定

Issue: #66