### PR TITLE
fix: 2FA認証のCookieベース認証を修正

### DIFF
--- a/backend/infrastructure/web/auth_middleware.go
+++ b/backend/infrastructure/web/auth_middleware.go
@@ -11,6 +11,7 @@ import (
 
 // JWTAuthMiddleware はJWT認証ミドルウェア
 // Cookieからトークンを取得し、なければAuthorizationヘッダーから取得（後方互換性のため）
+// 2FA仮トークン（Requires2FA: true）は2FA検証エンドポイントのみで許可される
 func JWTAuthMiddleware(authUseCase usecases.AuthUseCase) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -44,6 +45,15 @@ func JWTAuthMiddleware(authUseCase usecases.AuthUseCase) echo.MiddlewareFunc {
 			claims, err := authUseCase.VerifyToken(c.Request().Context(), tokenString)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusUnauthorized, "無効または期限切れの認証トークンです")
+			}
+
+			// 2FA仮トークンの場合、2FA検証エンドポイントのみ許可
+			if claims.Requires2FA || claims.TwoFactorVerify {
+				path := c.Request().URL.Path
+				// /api/auth/2fa/verify のみ許可
+				if !strings.HasSuffix(path, "/auth/2fa/verify") {
+					return echo.NewHTTPError(http.StatusUnauthorized, "2段階認証の検証が必要です")
+				}
 			}
 
 			// ユーザー情報をコンテキストに保存

--- a/backend/infrastructure/web/controllers/auth_controller.go
+++ b/backend/infrastructure/web/controllers/auth_controller.go
@@ -148,8 +148,14 @@ func (c *AuthController) Login(ctx echo.Context) error {
 		return ctx.JSON(http.StatusInternalServerError, NewErrorResponse(ctx, ErrorCodeInternalServer, "ログインに失敗しました", err.Error()))
 	}
 
-	// トークンをhttpOnly Cookieに設定
-	setAuthCookies(ctx, output.Token, output.RefreshToken, c.serverConfig)
+	// 2FA検証が必要な場合（RefreshTokenが空）は仮トークンのみをCookieに設定
+	if output.RefreshToken == "" {
+		// 2FA仮トークンをアクセストークンCookieに設定（5分間有効）
+		setAccessTokenCookie(ctx, output.Token, c.serverConfig)
+	} else {
+		// 通常のトークンをhttpOnly Cookieに設定
+		setAuthCookies(ctx, output.Token, output.RefreshToken, c.serverConfig)
+	}
 
 	response := AuthResponse{
 		UserID:       output.UserID,

--- a/backend/infrastructure/web/server.go
+++ b/backend/infrastructure/web/server.go
@@ -79,7 +79,7 @@ func NewControllers(deps *ServerDependencies) *Controllers {
 	// Create controllers
 	return &Controllers{
 		Auth:          controllers.NewAuthController(authUseCase, deps.ServerConfig),
-		TwoFactor:     controllers.NewTwoFactorController(authUseCase),
+		TwoFactor:     controllers.NewTwoFactorController(authUseCase, deps.ServerConfig),
 		FinancialData: controllers.NewFinancialDataController(manageFinancialDataUseCase),
 		Calculations:  controllers.NewCalculationsController(calculateProjectionUseCase),
 		Goals:         controllers.NewGoalsController(manageGoalsUseCase),

--- a/frontend/src/lib/contexts/AuthContext.tsx
+++ b/frontend/src/lib/contexts/AuthContext.tsx
@@ -114,9 +114,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const data: AuthResponse = await response.json();
       
       // リフレッシュトークンが空の場合は2FA検証が必要
+      // 仮トークンはCookieで自動的に設定されるため、localStorageへの保存は不要
       if (!data.refresh_token) {
-        // 仮トークンを一時保存（2FA検証まで使用）
-        localStorage.setItem(TEMP_TOKEN_KEY, data.token);
         // 2FA検証ページにリダイレクト
         router.push('/auth/2fa-verify');
       } else {


### PR DESCRIPTION
- ログイン時に2FA仮トークンをCookieに正しく設定
- JWTミドルウェアで2FA仮トークンを検出し、検証エンドポイント以外をブロック
- 2FA検証成功後に本物のトークンをCookieに設定
- フロントエンドのlocalStorage依存を削除（Cookie自動送信に統一）

Issue: #67