### PR TITLE
feat: add /api/rate-limit/status endpoint and X-RateLimit-* headers

### DIFF
--- a/backend/infrastructure/web/api_integration_test.go
+++ b/backend/infrastructure/web/api_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/financial-planning-calculator/backend/application/usecases"
 	"github.com/financial-planning-calculator/backend/config"
@@ -270,7 +271,8 @@ func setupTestServer() (*echo.Echo, *MockManageFinancialDataUseCase, *MockCalcul
 	}
 
 	// Setup routes
-	SetupRoutes(e, controllers, deps)
+	testStore := NewCustomRateLimiterStore(100, 50, 3*time.Minute)
+	SetupRoutes(e, controllers, deps, testStore)
 
 	return e, mockFinancialUseCase, mockCalculationUseCase, mockGoalsUseCase, mockReportsUseCase
 }

--- a/backend/infrastructure/web/ratelimit_store.go
+++ b/backend/infrastructure/web/ratelimit_store.go
@@ -1,0 +1,122 @@
+package web
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// RateLimitInfo holds the current rate limit status for a given identifier.
+type RateLimitInfo struct {
+	Limit     int       `json:"limit"`
+	Remaining int       `json:"remaining"`
+	Reset     int64     `json:"reset"`     // Unix timestamp (seconds)
+	ResetAt   time.Time `json:"reset_at"`  // Human-readable reset time
+}
+
+// rateLimiterEntry holds a per-IP limiter and the last access time (for expiry).
+type rateLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// CustomRateLimiterStore is a thread-safe in-memory rate limiter store that
+// implements echo middleware.RateLimiterStore and exposes per-IP limit info.
+type CustomRateLimiterStore struct {
+	rateLimit rate.Limit
+	burst     int
+	expiresIn time.Duration
+
+	mu       sync.Mutex
+	limiters map[string]*rateLimiterEntry
+}
+
+// NewCustomRateLimiterStore creates a new CustomRateLimiterStore.
+func NewCustomRateLimiterStore(rps float64, burst int, expiresIn time.Duration) *CustomRateLimiterStore {
+	store := &CustomRateLimiterStore{
+		rateLimit: rate.Limit(rps),
+		burst:     burst,
+		expiresIn: expiresIn,
+		limiters:  make(map[string]*rateLimiterEntry),
+	}
+	// Start background cleanup goroutine
+	go store.cleanup()
+	return store
+}
+
+// Allow implements echo middleware.RateLimiterStore.
+// Returns true if the request is allowed, false if rate-limited.
+func (s *CustomRateLimiterStore) Allow(identifier string) (bool, error) {
+	entry := s.getOrCreate(identifier)
+	return entry.limiter.Allow(), nil
+}
+
+// GetInfo returns the current rate limit status for the given identifier.
+// This does NOT consume a token.
+func (s *CustomRateLimiterStore) GetInfo(identifier string) RateLimitInfo {
+	entry := s.getOrCreate(identifier)
+	limiter := entry.limiter
+
+	// Current available tokens (float64, may be fractional)
+	tokens := limiter.Tokens()
+	if tokens < 0 {
+		tokens = 0
+	}
+	remaining := int(math.Floor(tokens))
+
+	// Calculate reset time: time until the bucket is full (burst capacity)
+	var resetAt time.Time
+	if remaining < s.burst {
+		// Tokens missing to reach burst
+		missing := float64(s.burst) - tokens
+		// Time in seconds to refill 'missing' tokens at rate rps
+		secondsToFull := missing / float64(s.rateLimit)
+		resetAt = time.Now().Add(time.Duration(secondsToFull * float64(time.Second)))
+	} else {
+		// Already full
+		resetAt = time.Now()
+	}
+
+	return RateLimitInfo{
+		Limit:     s.burst,
+		Remaining: remaining,
+		Reset:     resetAt.Unix(),
+		ResetAt:   resetAt.UTC(),
+	}
+}
+
+// getOrCreate retrieves an existing limiter or creates a new one for the identifier.
+func (s *CustomRateLimiterStore) getOrCreate(identifier string) *rateLimiterEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.limiters[identifier]
+	if !ok {
+		entry = &rateLimiterEntry{
+			limiter: rate.NewLimiter(s.rateLimit, s.burst),
+		}
+		s.limiters[identifier] = entry
+	}
+	entry.lastSeen = time.Now()
+	return entry
+}
+
+// cleanup removes expired entries periodically to prevent memory leaks.
+func (s *CustomRateLimiterStore) cleanup() {
+	// Run cleanup at half the expiry interval
+	ticker := time.NewTicker(s.expiresIn / 2)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		s.mu.Lock()
+		now := time.Now()
+		for id, entry := range s.limiters {
+			if now.Sub(entry.lastSeen) > s.expiresIn {
+				delete(s.limiters, id)
+			}
+		}
+		s.mu.Unlock()
+	}
+}

--- a/backend/infrastructure/web/ratelimit_store_test.go
+++ b/backend/infrastructure/web/ratelimit_store_test.go
@@ -1,0 +1,108 @@
+package web
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCustomRateLimiterStore(t *testing.T) {
+	store := NewCustomRateLimiterStore(10, 5, time.Minute)
+	require.NotNil(t, store)
+	assert.Equal(t, 5, store.burst)
+}
+
+func TestCustomRateLimiterStore_Allow(t *testing.T) {
+	// burst=3, rps=100 → 3 requests should be allowed immediately
+	store := NewCustomRateLimiterStore(100, 3, time.Minute)
+
+	for i := 0; i < 3; i++ {
+		allowed, err := store.Allow("127.0.0.1")
+		require.NoError(t, err)
+		assert.True(t, allowed, "request %d should be allowed", i+1)
+	}
+
+	// 4th request should be denied (burst exhausted)
+	allowed, err := store.Allow("127.0.0.1")
+	require.NoError(t, err)
+	assert.False(t, allowed, "4th request should be denied")
+}
+
+func TestCustomRateLimiterStore_Allow_DifferentIdentifiers(t *testing.T) {
+	store := NewCustomRateLimiterStore(100, 1, time.Minute)
+
+	// First request for each IP should be allowed
+	ok1, _ := store.Allow("192.168.0.1")
+	ok2, _ := store.Allow("192.168.0.2")
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+
+	// Second request for each IP should be denied
+	ok1again, _ := store.Allow("192.168.0.1")
+	ok2again, _ := store.Allow("192.168.0.2")
+	assert.False(t, ok1again)
+	assert.False(t, ok2again)
+}
+
+func TestCustomRateLimiterStore_GetInfo_Full(t *testing.T) {
+	burst := 10
+	store := NewCustomRateLimiterStore(1, burst, time.Minute)
+
+	// No requests consumed yet → remaining should equal burst
+	info := store.GetInfo("10.0.0.1")
+
+	assert.Equal(t, burst, info.Limit)
+	assert.Equal(t, burst, info.Remaining)
+	// When full, reset is approximately now
+	assert.WithinDuration(t, time.Now(), info.ResetAt, 2*time.Second)
+}
+
+func TestCustomRateLimiterStore_GetInfo_AfterConsumption(t *testing.T) {
+	burst := 5
+	store := NewCustomRateLimiterStore(1, burst, time.Minute)
+	ip := "10.0.0.2"
+
+	// Consume 3 tokens
+	for i := 0; i < 3; i++ {
+		store.Allow(ip) //nolint:errcheck
+	}
+
+	info := store.GetInfo(ip)
+	assert.Equal(t, burst, info.Limit)
+	// Remaining should be around burst-3 (may be slightly different due to time-based refill)
+	assert.LessOrEqual(t, info.Remaining, burst-3)
+	// Reset time should be in the future
+	assert.True(t, info.ResetAt.After(time.Now()) || math.Abs(float64(info.Remaining-burst)) < 1,
+		"reset should be in the future when tokens are missing")
+}
+
+func TestCustomRateLimiterStore_GetInfo_DoesNotConsumeToken(t *testing.T) {
+	burst := 5
+	store := NewCustomRateLimiterStore(100, burst, time.Minute)
+	ip := "10.0.0.3"
+
+	// Call GetInfo multiple times without Allow
+	for i := 0; i < 10; i++ {
+		info := store.GetInfo(ip)
+		assert.Equal(t, burst, info.Remaining, "GetInfo should not consume tokens")
+	}
+}
+
+func TestCustomRateLimiterStore_GetInfo_ResetFields(t *testing.T) {
+	store := NewCustomRateLimiterStore(1, 3, time.Minute)
+	ip := "10.0.0.4"
+
+	// Consume all tokens at rps=1 so reset will be in the future
+	store.Allow(ip) //nolint:errcheck
+	store.Allow(ip) //nolint:errcheck
+	store.Allow(ip) //nolint:errcheck
+
+	info := store.GetInfo(ip)
+	// Reset Unix timestamp should be non-zero and in the future
+	assert.Greater(t, info.Reset, time.Now().Unix()-1)
+	// ResetAt should not be zero value
+	assert.False(t, info.ResetAt.IsZero())
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -46,7 +46,7 @@ func main() {
 	e.HTTPErrorHandler = web.CustomHTTPErrorHandler
 
 	// ミドルウェア設定
-	web.SetupMiddleware(e, cfg)
+	rateLimitStore := web.SetupMiddleware(e, cfg)
 
 	// 依存関係の初期化
 	deps := initializeDependencies()
@@ -55,7 +55,7 @@ func main() {
 	controllers := web.NewControllers(deps)
 
 	// ルーティング設定
-	web.SetupRoutes(e, controllers, deps)
+	web.SetupRoutes(e, controllers, deps, rateLimitStore)
 
 	// pprofサーバーの起動（開発環境のみ）
 	if cfg.EnablePprof {


### PR DESCRIPTION
- Implement CustomRateLimiterStore (ratelimit_store.go) wrapping golang.org/x/time/rate.Limiter with GetInfo() for per-IP token inspection
- Replace Echo standard RateLimiterMemoryStore with CustomRateLimiterStore so remaining token count and reset time are accessible without consuming tokens
- Add RateLimitHeaderMiddleware to attach X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset headers to every response
- Add GET /api/rate-limit/status endpoint (no auth required) returning: { limit, remaining, reset (unix), reset_at (RFC3339) }
- Update SetupMiddleware to return *CustomRateLimiterStore; update SetupRoutes to accept and wire the store
- Add unit tests: TestCustomRateLimiterStore_*, TestRateLimitStatusHandler, TestRateLimitStatusHandler_RemainingDecreases (9 new tests, all PASS)