### PR TITLE
feat(auth): パスワードリセット機能のバックエンドAPI実装 Issue: #145

### DIFF
--- a/backend/application/usecases/auth_usecase.go
+++ b/backend/application/usecases/auth_usecase.go
@@ -58,6 +58,12 @@ type AuthUseCase interface {
 
 	// Get2FAStatus は2FAの有効状態を取得する
 	Get2FAStatus(ctx context.Context, userID string) (*Get2FAStatusOutput, error)
+
+	// ForgotPassword はパスワードリセットメールを送信する
+	ForgotPassword(ctx context.Context, input ForgotPasswordInput) error
+
+	// ResetPassword はトークンを使ってパスワードをリセットする
+	ResetPassword(ctx context.Context, input ResetPasswordInput) error
 }
 
 // Get2FAStatusOutput は2FAステータス取得の出力
@@ -150,19 +156,40 @@ type RegenerateBackupCodesOutput struct {
 	BackupCodes []string `json:"backup_codes"`
 }
 
+// ForgotPasswordInput はパスワードリセットメール送信の入力
+type ForgotPasswordInput struct {
+	Email       string `json:"email"`
+	FrontendURL string `json:"-"`
+}
+
+// ResetPasswordInput はパスワードリセットの入力
+type ResetPasswordInput struct {
+	Token       string `json:"token"`
+	NewPassword string `json:"new_password"`
+}
+
+// emailSender はメール送信の抽象（循環インポートを避けるための最小インターフェース）
+type emailSender interface {
+	SendPasswordResetEmail(ctx context.Context, toEmail, resetURL string) error
+}
+
 // authUseCase は認証ユースケースの実装
 type authUseCase struct {
-	userRepo                repositories.UserRepository
-	refreshTokenRepo        repositories.RefreshTokenRepository
-	jwtSecret               string
-	jwtExpiration           time.Duration
-	refreshTokenExpiration  time.Duration
+	userRepo               repositories.UserRepository
+	refreshTokenRepo       repositories.RefreshTokenRepository
+	passwordResetTokenRepo repositories.PasswordResetTokenRepository
+	emailService           emailSender
+	jwtSecret              string
+	jwtExpiration          time.Duration
+	refreshTokenExpiration time.Duration
 }
 
 // NewAuthUseCase は新しい認証ユースケースを作成する
 func NewAuthUseCase(
 	userRepo repositories.UserRepository,
 	refreshTokenRepo repositories.RefreshTokenRepository,
+	passwordResetTokenRepo repositories.PasswordResetTokenRepository,
+	emailService emailSender,
 	jwtSecret string,
 	jwtExpiration time.Duration,
 	refreshTokenExpiration time.Duration,
@@ -170,6 +197,8 @@ func NewAuthUseCase(
 	return &authUseCase{
 		userRepo:               userRepo,
 		refreshTokenRepo:       refreshTokenRepo,
+		passwordResetTokenRepo: passwordResetTokenRepo,
+		emailService:           emailService,
 		jwtSecret:              jwtSecret,
 		jwtExpiration:          jwtExpiration,
 		refreshTokenExpiration: refreshTokenExpiration,
@@ -897,4 +926,107 @@ func (uc *authUseCase) Get2FAStatus(ctx context.Context, userID string) (*Get2FA
 	return &Get2FAStatusOutput{
 		Enabled: user.TwoFactorEnabled(),
 	}, nil
+}
+
+// ForgotPassword はパスワードリセットメールを送信する
+// 存在しないメールアドレスでも同じレスポンスを返す（ユーザー列挙対策）
+func (uc *authUseCase) ForgotPassword(ctx context.Context, input ForgotPasswordInput) error {
+	logger := slog.With("usecase", "ForgotPassword")
+	logger.InfoContext(ctx, "パスワードリセットリクエストを受け付けました")
+
+	email, err := entities.NewEmail(input.Email)
+	if err != nil {
+		// バリデーションエラーでも成功として扱う（ユーザー列挙対策）
+		return nil
+	}
+
+	user, err := uc.userRepo.FindByEmail(ctx, email)
+	if err != nil || user == nil {
+		// 存在しないメールでも成功として扱う（ユーザー列挙対策）
+		return nil
+	}
+
+	// 既存のリセットトークンを削除
+	if err := uc.passwordResetTokenRepo.DeleteByUserID(ctx, user.ID()); err != nil {
+		logger.ErrorContext(ctx, "既存トークンの削除に失敗しました", "error", err)
+		return nil
+	}
+
+	// 新しいリセットトークンを生成（有効期限30分）
+	expiresAt := time.Now().Add(30 * time.Minute)
+	token, plainToken, err := entities.NewPasswordResetToken(user.ID(), expiresAt)
+	if err != nil {
+		logger.ErrorContext(ctx, "リセットトークンの生成に失敗しました", "error", err)
+		return nil
+	}
+
+	if err := uc.passwordResetTokenRepo.Save(ctx, token); err != nil {
+		logger.ErrorContext(ctx, "リセットトークンの保存に失敗しました", "error", err)
+		return nil
+	}
+
+	resetURL := fmt.Sprintf("%s/reset-password?token=%s", input.FrontendURL, plainToken)
+	if err := uc.emailService.SendPasswordResetEmail(ctx, string(email), resetURL); err != nil {
+		logger.ErrorContext(ctx, "リセットメールの送信に失敗しました", "error", err)
+		// メール送信失敗でも成功として扱う（ユーザー列挙対策）
+	}
+
+	return nil
+}
+
+// ResetPassword はトークンを使ってパスワードをリセットする
+func (uc *authUseCase) ResetPassword(ctx context.Context, input ResetPasswordInput) error {
+	logger := slog.With("usecase", "ResetPassword")
+	logger.InfoContext(ctx, "パスワードリセットを開始します")
+
+	if input.Token == "" {
+		return errors.New("トークンは必須です")
+	}
+	if input.NewPassword == "" {
+		return errors.New("新しいパスワードは必須です")
+	}
+
+	// トークンのハッシュを計算して検索
+	tokenHash := sha256HexToken(input.Token)
+	resetToken, err := uc.passwordResetTokenRepo.FindByTokenHash(ctx, tokenHash)
+	if err != nil {
+		logger.ErrorContext(ctx, "トークンの検索に失敗しました", "error", err)
+		return errors.New("無効なトークンです")
+	}
+	if resetToken == nil || !resetToken.IsValid() {
+		return errors.New("無効または期限切れのトークンです")
+	}
+
+	// ユーザーを取得
+	user, err := uc.userRepo.FindByID(ctx, resetToken.UserID())
+	if err != nil || user == nil {
+		logger.ErrorContext(ctx, "ユーザーの取得に失敗しました", "error", err)
+		return errors.New("ユーザーが見つかりません")
+	}
+
+	// パスワードを更新
+	if err := user.UpdatePassword(input.NewPassword); err != nil {
+		return fmt.Errorf("パスワードの更新に失敗しました: %w", err)
+	}
+
+	if err := uc.userRepo.Update(ctx, user); err != nil {
+		logger.ErrorContext(ctx, "ユーザーの保存に失敗しました", "error", err)
+		return fmt.Errorf("パスワードの保存に失敗しました: %w", err)
+	}
+
+	// トークンを使用済みにする
+	resetToken.Use()
+	if err := uc.passwordResetTokenRepo.Update(ctx, resetToken); err != nil {
+		logger.ErrorContext(ctx, "トークンの更新に失敗しました", "error", err)
+		// パスワードは既に更新済みのためエラーは返さない
+	}
+
+	logger.InfoContext(ctx, "パスワードリセット完了", "user_id", string(resetToken.UserID()))
+	return nil
+}
+
+// sha256HexToken は文字列をSHA-256でハッシュ化してhex文字列を返す
+func sha256HexToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
 }

--- a/backend/application/usecases/auth_usecase_test.go
+++ b/backend/application/usecases/auth_usecase_test.go
@@ -18,7 +18,9 @@ const (
 )
 
 func newTestAuthUseCase(userRepo *MockUserRepository, tokenRepo *MockRefreshTokenRepository) AuthUseCase {
-	return NewAuthUseCase(userRepo, tokenRepo, testJWTSecret, testJWTExpiration, testRefreshTokenExpiration)
+	passwordResetRepo := new(MockPasswordResetTokenRepository)
+	emailService := new(MockEmailService)
+	return NewAuthUseCase(userRepo, tokenRepo, passwordResetRepo, emailService, testJWTSecret, testJWTExpiration, testRefreshTokenExpiration)
 }
 
 // ===========================

--- a/backend/application/usecases/mock_repositories_test.go
+++ b/backend/application/usecases/mock_repositories_test.go
@@ -284,3 +284,60 @@ func (m *MockWebAuthnCredentialRepository) Delete(ctx context.Context, id entiti
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
+
+// -------------------------------------------------------------------
+// MockPasswordResetTokenRepository
+// -------------------------------------------------------------------
+
+type MockPasswordResetTokenRepository struct {
+	mock.Mock
+}
+
+func (m *MockPasswordResetTokenRepository) Save(ctx context.Context, token *entities.PasswordResetToken) error {
+	args := m.Called(ctx, token)
+	return args.Error(0)
+}
+
+func (m *MockPasswordResetTokenRepository) FindByTokenHash(ctx context.Context, tokenHash string) (*entities.PasswordResetToken, error) {
+	args := m.Called(ctx, tokenHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entities.PasswordResetToken), args.Error(1)
+}
+
+func (m *MockPasswordResetTokenRepository) FindByUserID(ctx context.Context, userID entities.UserID) ([]*entities.PasswordResetToken, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*entities.PasswordResetToken), args.Error(1)
+}
+
+func (m *MockPasswordResetTokenRepository) Update(ctx context.Context, token *entities.PasswordResetToken) error {
+	args := m.Called(ctx, token)
+	return args.Error(0)
+}
+
+func (m *MockPasswordResetTokenRepository) DeleteExpired(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockPasswordResetTokenRepository) DeleteByUserID(ctx context.Context, userID entities.UserID) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+// -------------------------------------------------------------------
+// MockEmailService
+// -------------------------------------------------------------------
+
+type MockEmailService struct {
+	mock.Mock
+}
+
+func (m *MockEmailService) SendPasswordResetEmail(ctx context.Context, toEmail, resetURL string) error {
+	args := m.Called(ctx, toEmail, resetURL)
+	return args.Error(0)
+}

--- a/backend/config/server.go
+++ b/backend/config/server.go
@@ -51,6 +51,14 @@ type ServerConfig struct {
 	WebAuthnRPOrigin         string // Relying Party Origin (e.g., "https://example.com")
 	// CSP
 	ContentSecurityPolicy   string // Content-Security-Policy ヘッダー値（空文字の場合はヘッダーを設定しない）
+	// SMTP メール設定
+	SMTPHost     string // SMTP_HOST
+	SMTPPort     int    // SMTP_PORT
+	SMTPUser     string // SMTP_USER
+	SMTPPassword string // SMTP_PASSWORD
+	SMTPFrom     string // SMTP_FROM
+	// フロントエンドURL（パスワードリセットURLの生成に使用）
+	FrontendURL  string // FRONTEND_URL
 }
 
 // LoadServerConfig loads server configuration from environment variables
@@ -100,6 +108,14 @@ func LoadServerConfig() *ServerConfig {
 		// 本番環境では CONTENT_SECURITY_POLICY 環境変数で上書き可能
 		// 開発環境では ENABLE_SECURE_HEADERS=false でヘッダー自体を無効化する
 		ContentSecurityPolicy: getEnv("CONTENT_SECURITY_POLICY", "default-src 'none'; frame-ancestors 'none'; form-action 'none'"),
+		// SMTP メール設定
+		SMTPHost:     getEnv("SMTP_HOST", ""),
+		SMTPPort:     getEnvInt("SMTP_PORT", 587),
+		SMTPUser:     getEnv("SMTP_USER", ""),
+		SMTPPassword: getEnv("SMTP_PASSWORD", ""),
+		SMTPFrom:     getEnv("SMTP_FROM", "noreply@example.com"),
+		// フロントエンドURL
+		FrontendURL: getEnv("FRONTEND_URL", "http://localhost:3000"),
 	}
 
 	return config

--- a/backend/domain/entities/password_reset_token.go
+++ b/backend/domain/entities/password_reset_token.go
@@ -1,0 +1,93 @@
+package entities
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PasswordResetTokenID はパスワードリセットトークンの一意識別子
+type PasswordResetTokenID string
+
+// PasswordResetToken はパスワードリセットトークンエンティティ
+type PasswordResetToken struct {
+	id        PasswordResetTokenID
+	userID    UserID
+	tokenHash string
+	expiresAt time.Time
+	isUsed    bool
+	createdAt time.Time
+}
+
+// NewPasswordResetToken は新しいパスワードリセットトークンを生成する
+// 返値: (エンティティ, 平文トークン, エラー)
+func NewPasswordResetToken(userID UserID, expiresAt time.Time) (*PasswordResetToken, string, error) {
+	if string(userID) == "" {
+		return nil, "", errors.New("ユーザーIDは必須です")
+	}
+
+	// 32バイトのランダムトークンを生成
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return nil, "", fmt.Errorf("トークン生成に失敗しました: %w", err)
+	}
+
+	plainToken := hex.EncodeToString(randomBytes)
+	tokenHash := hashToken(plainToken)
+
+	return &PasswordResetToken{
+		id:        PasswordResetTokenID(uuid.New().String()),
+		userID:    userID,
+		tokenHash: tokenHash,
+		expiresAt: expiresAt,
+		isUsed:    false,
+		createdAt: time.Now(),
+	}, plainToken, nil
+}
+
+// ReconstructPasswordResetToken はDBから取得したデータからエンティティを再構築する
+func ReconstructPasswordResetToken(id string, userID UserID, tokenHash string, expiresAt time.Time, isUsed bool, createdAt time.Time) *PasswordResetToken {
+	return &PasswordResetToken{
+		id:        PasswordResetTokenID(id),
+		userID:    userID,
+		tokenHash: tokenHash,
+		expiresAt: expiresAt,
+		isUsed:    isUsed,
+		createdAt: createdAt,
+	}
+}
+
+// Getters
+
+func (t *PasswordResetToken) ID() PasswordResetTokenID { return t.id }
+func (t *PasswordResetToken) UserID() UserID           { return t.userID }
+func (t *PasswordResetToken) TokenHash() string        { return t.tokenHash }
+func (t *PasswordResetToken) ExpiresAt() time.Time     { return t.expiresAt }
+func (t *PasswordResetToken) IsUsed() bool             { return t.isUsed }
+func (t *PasswordResetToken) CreatedAt() time.Time     { return t.createdAt }
+
+// IsExpired はトークンが期限切れかどうかを返す
+func (t *PasswordResetToken) IsExpired() bool {
+	return time.Now().After(t.expiresAt)
+}
+
+// IsValid はトークンが有効かどうかを返す（未使用かつ期限内）
+func (t *PasswordResetToken) IsValid() bool {
+	return !t.isUsed && !t.IsExpired()
+}
+
+// VerifyToken は平文トークンがこのエンティティのものと一致するか検証する
+func (t *PasswordResetToken) VerifyToken(plainToken string) bool {
+	return hashToken(plainToken) == t.tokenHash
+}
+
+// Use はトークンを使用済みにする
+func (t *PasswordResetToken) Use() {
+	t.isUsed = true
+}
+
+

--- a/backend/domain/repositories/password_reset_token_repository.go
+++ b/backend/domain/repositories/password_reset_token_repository.go
@@ -1,0 +1,28 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/financial-planning-calculator/backend/domain/entities"
+)
+
+// PasswordResetTokenRepository はパスワードリセットトークンの永続化を担当するリポジトリインターフェース
+type PasswordResetTokenRepository interface {
+	// Save は新しいトークンを保存する
+	Save(ctx context.Context, token *entities.PasswordResetToken) error
+
+	// FindByTokenHash はトークンハッシュからトークンを取得する
+	FindByTokenHash(ctx context.Context, tokenHash string) (*entities.PasswordResetToken, error)
+
+	// FindByUserID はユーザーIDに紐づくトークン一覧を取得する
+	FindByUserID(ctx context.Context, userID entities.UserID) ([]*entities.PasswordResetToken, error)
+
+	// Update は既存のトークンを更新する（使用済みフラグの更新などに使用）
+	Update(ctx context.Context, token *entities.PasswordResetToken) error
+
+	// DeleteExpired は期限切れのトークンを全て削除する
+	DeleteExpired(ctx context.Context) error
+
+	// DeleteByUserID は指定ユーザーのトークンを全て削除する
+	DeleteByUserID(ctx context.Context, userID entities.UserID) error
+}

--- a/backend/infrastructure/database/migrations/008_create_password_reset_tokens_table.sql
+++ b/backend/infrastructure/database/migrations/008_create_password_reset_tokens_table.sql
@@ -1,0 +1,13 @@
+-- パスワードリセットトークンテーブルの作成
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id VARCHAR(255) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    is_used BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_prt_user_id ON password_reset_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_prt_token_hash ON password_reset_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_prt_expires_at ON password_reset_tokens(expires_at);

--- a/backend/infrastructure/database/migrations/008_create_password_reset_tokens_table_down.sql
+++ b/backend/infrastructure/database/migrations/008_create_password_reset_tokens_table_down.sql
@@ -1,0 +1,2 @@
+-- パスワードリセットトークンテーブルの削除
+DROP TABLE IF EXISTS password_reset_tokens;

--- a/backend/infrastructure/email/email_service.go
+++ b/backend/infrastructure/email/email_service.go
@@ -1,0 +1,86 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/smtp"
+)
+
+// EmailService はメール送信サービスのインターフェース
+type EmailService interface {
+	SendPasswordResetEmail(ctx context.Context, toEmail, resetURL string) error
+}
+
+// LogEmailService は開発用のメールサービス（stdoutにログ出力）
+type LogEmailService struct{}
+
+// NewLogEmailService は開発用メールサービスを作成する
+func NewLogEmailService() EmailService {
+	return &LogEmailService{}
+}
+
+// SendPasswordResetEmail はリセットURLをログに出力する（開発用）
+func (s *LogEmailService) SendPasswordResetEmail(_ context.Context, toEmail, resetURL string) error {
+	slog.Info("パスワードリセットメール（開発モード）",
+		"to", toEmail,
+		"reset_url", resetURL,
+	)
+	return nil
+}
+
+// SMTPEmailService はSMTPを使ったメールサービス
+type SMTPEmailService struct {
+	host     string
+	port     int
+	user     string
+	password string
+	from     string
+}
+
+// NewSMTPEmailService はSMTPメールサービスを作成する
+func NewSMTPEmailService(host string, port int, user, password, from string) EmailService {
+	return &SMTPEmailService{
+		host:     host,
+		port:     port,
+		user:     user,
+		password: password,
+		from:     from,
+	}
+}
+
+// SendPasswordResetEmail はパスワードリセットメールをSMTPで送信する
+func (s *SMTPEmailService) SendPasswordResetEmail(_ context.Context, toEmail, resetURL string) error {
+	subject := "パスワードリセットのご案内"
+	body := fmt.Sprintf(`パスワードリセットのリクエストを受け付けました。
+
+以下のURLをクリックしてパスワードをリセットしてください（有効期限: 30分）:
+
+%s
+
+このメールに心当たりがない場合は無視してください。
+`, resetURL)
+
+	msg := []byte(fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
+		s.from, toEmail, subject, body,
+	))
+
+	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	auth := smtp.PlainAuth("", s.user, s.password, s.host)
+
+	if err := smtp.SendMail(addr, auth, s.from, []string{toEmail}, msg); err != nil {
+		return fmt.Errorf("メール送信に失敗しました: %w", err)
+	}
+	return nil
+}
+
+// NewEmailService はSMTP設定に基づいてメールサービスを作成する
+// SMTP設定がない場合はログ出力のフォールバックを使用する
+func NewEmailService(host string, port int, user, password, from string) EmailService {
+	if host == "" {
+		slog.Warn("SMTP設定がないため開発用メールサービス（ログ出力）を使用します")
+		return NewLogEmailService()
+	}
+	return NewSMTPEmailService(host, port, user, password, from)
+}

--- a/backend/infrastructure/repositories/postgresql_password_reset_token_repository.go
+++ b/backend/infrastructure/repositories/postgresql_password_reset_token_repository.go
@@ -1,0 +1,156 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/financial-planning-calculator/backend/domain/entities"
+	"github.com/financial-planning-calculator/backend/domain/repositories"
+)
+
+// PostgreSQLPasswordResetTokenRepository はPostgreSQLを使ったパスワードリセットトークンリポジトリ
+type PostgreSQLPasswordResetTokenRepository struct {
+	db *sql.DB
+}
+
+// NewPostgreSQLPasswordResetTokenRepository は新しいリポジトリを作成する
+func NewPostgreSQLPasswordResetTokenRepository(db *sql.DB) repositories.PasswordResetTokenRepository {
+	return &PostgreSQLPasswordResetTokenRepository{db: db}
+}
+
+// Save は新しいトークンを保存する
+func (r *PostgreSQLPasswordResetTokenRepository) Save(ctx context.Context, token *entities.PasswordResetToken) error {
+	query := `
+		INSERT INTO password_reset_tokens (id, user_id, token_hash, expires_at, is_used, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`
+	_, err := r.db.ExecContext(ctx, query,
+		string(token.ID()),
+		string(token.UserID()),
+		token.TokenHash(),
+		token.ExpiresAt(),
+		token.IsUsed(),
+		token.CreatedAt(),
+	)
+	if err != nil {
+		return fmt.Errorf("パスワードリセットトークンの保存に失敗しました: %w", err)
+	}
+	return nil
+}
+
+// FindByTokenHash はトークンハッシュからトークンを取得する
+func (r *PostgreSQLPasswordResetTokenRepository) FindByTokenHash(ctx context.Context, tokenHash string) (*entities.PasswordResetToken, error) {
+	query := `
+		SELECT id, user_id, token_hash, expires_at, is_used, created_at
+		FROM password_reset_tokens
+		WHERE token_hash = $1
+	`
+	row := r.db.QueryRowContext(ctx, query, tokenHash)
+	return scanPasswordResetToken(row)
+}
+
+// FindByUserID はユーザーIDに紐づくトークン一覧を取得する
+func (r *PostgreSQLPasswordResetTokenRepository) FindByUserID(ctx context.Context, userID entities.UserID) ([]*entities.PasswordResetToken, error) {
+	query := `
+		SELECT id, user_id, token_hash, expires_at, is_used, created_at
+		FROM password_reset_tokens
+		WHERE user_id = $1
+		ORDER BY created_at DESC
+	`
+	rows, err := r.db.QueryContext(ctx, query, string(userID))
+	if err != nil {
+		return nil, fmt.Errorf("パスワードリセットトークンの取得に失敗しました: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []*entities.PasswordResetToken
+	for rows.Next() {
+		token, err := scanPasswordResetTokenRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, token)
+	}
+	return tokens, rows.Err()
+}
+
+// Update は既存のトークンを更新する
+func (r *PostgreSQLPasswordResetTokenRepository) Update(ctx context.Context, token *entities.PasswordResetToken) error {
+	query := `
+		UPDATE password_reset_tokens
+		SET is_used = $1
+		WHERE id = $2
+	`
+	result, err := r.db.ExecContext(ctx, query, token.IsUsed(), string(token.ID()))
+	if err != nil {
+		return fmt.Errorf("パスワードリセットトークンの更新に失敗しました: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("更新行数の取得に失敗しました: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("パスワードリセットトークンが見つかりません: %s", string(token.ID()))
+	}
+	return nil
+}
+
+// DeleteExpired は期限切れのトークンを全て削除する
+func (r *PostgreSQLPasswordResetTokenRepository) DeleteExpired(ctx context.Context) error {
+	query := `DELETE FROM password_reset_tokens WHERE expires_at < $1`
+	_, err := r.db.ExecContext(ctx, query, time.Now())
+	if err != nil {
+		return fmt.Errorf("期限切れトークンの削除に失敗しました: %w", err)
+	}
+	return nil
+}
+
+// DeleteByUserID は指定ユーザーのトークンを全て削除する
+func (r *PostgreSQLPasswordResetTokenRepository) DeleteByUserID(ctx context.Context, userID entities.UserID) error {
+	query := `DELETE FROM password_reset_tokens WHERE user_id = $1`
+	_, err := r.db.ExecContext(ctx, query, string(userID))
+	if err != nil {
+		return fmt.Errorf("ユーザーのトークン削除に失敗しました: %w", err)
+	}
+	return nil
+}
+
+// scanPasswordResetToken は単一行をスキャンしてエンティティを返す
+func scanPasswordResetToken(row *sql.Row) (*entities.PasswordResetToken, error) {
+	var (
+		id        string
+		userID    string
+		tokenHash string
+		expiresAt time.Time
+		isUsed    bool
+		createdAt time.Time
+	)
+	err := row.Scan(&id, &userID, &tokenHash, &expiresAt, &isUsed, &createdAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("パスワードリセットトークンのスキャンに失敗しました: %w", err)
+	}
+	return entities.ReconstructPasswordResetToken(id, entities.UserID(userID), tokenHash, expiresAt, isUsed, createdAt), nil
+}
+
+// scanPasswordResetTokenRows は複数行から1行をスキャンしてエンティティを返す
+func scanPasswordResetTokenRows(rows *sql.Rows) (*entities.PasswordResetToken, error) {
+	var (
+		id        string
+		userID    string
+		tokenHash string
+		expiresAt time.Time
+		isUsed    bool
+		createdAt time.Time
+	)
+	err := rows.Scan(&id, &userID, &tokenHash, &expiresAt, &isUsed, &createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("パスワードリセットトークンのスキャンに失敗しました: %w", err)
+	}
+	return entities.ReconstructPasswordResetToken(id, entities.UserID(userID), tokenHash, expiresAt, isUsed, createdAt), nil
+}

--- a/backend/infrastructure/repositories/repository_factory.go
+++ b/backend/infrastructure/repositories/repository_factory.go
@@ -40,3 +40,8 @@ func (f *RepositoryFactory) NewGoalRepository() repositories.GoalRepository {
 func (f *RepositoryFactory) NewWebAuthnCredentialRepository() repositories.WebAuthnCredentialRepository {
 	return NewPostgreSQLWebAuthnCredentialRepository(f.db)
 }
+
+// NewPasswordResetTokenRepository はパスワードリセットトークンリポジトリを作成する
+func (f *RepositoryFactory) NewPasswordResetTokenRepository() repositories.PasswordResetTokenRepository {
+	return NewPostgreSQLPasswordResetTokenRepository(f.db)
+}

--- a/backend/infrastructure/web/controllers/auth_controller.go
+++ b/backend/infrastructure/web/controllers/auth_controller.go
@@ -298,3 +298,63 @@ func (c *AuthController) Logout(ctx echo.Context) error {
 		"message": "ログアウトしました",
 	})
 }
+
+// ForgotPasswordRequest はパスワードリセットメール送信リクエスト
+type ForgotPasswordRequest struct {
+	Email string `json:"email" validate:"required,email"`
+}
+
+// ResetPasswordRequest はパスワードリセットリクエスト
+type ResetPasswordRequest struct {
+	Token       string `json:"token" validate:"required"`
+	NewPassword string `json:"new_password" validate:"required,min=8"`
+}
+
+// ForgotPassword はパスワードリセットメールを送信する
+// ユーザー列挙対策のため、メールアドレスの存否に関わらず200を返す
+func (c *AuthController) ForgotPassword(ctx echo.Context) error {
+	var req ForgotPasswordRequest
+	if err := ctx.Bind(&req); err != nil {
+		return ctx.JSON(http.StatusBadRequest, NewErrorResponse(ctx, ErrorCodeBadRequest, "リクエストの解析に失敗しました", err.Error()))
+	}
+
+	input := usecases.ForgotPasswordInput{
+		Email:       req.Email,
+		FrontendURL: c.serverConfig.FrontendURL,
+	}
+
+	// エラーは無視（ユーザー列挙対策）
+	_ = c.authUseCase.ForgotPassword(ctx.Request().Context(), input)
+
+	return ctx.JSON(http.StatusOK, map[string]string{
+		"message": "パスワードリセットのメールを送信しました（登録済みの場合）",
+	})
+}
+
+// ResetPassword はトークンを使ってパスワードをリセットする
+func (c *AuthController) ResetPassword(ctx echo.Context) error {
+	var req ResetPasswordRequest
+	if err := ctx.Bind(&req); err != nil {
+		return ctx.JSON(http.StatusBadRequest, NewErrorResponse(ctx, ErrorCodeBadRequest, "リクエストの解析に失敗しました", err.Error()))
+	}
+
+	if err := ctx.Validate(&req); err != nil {
+		return err
+	}
+
+	input := usecases.ResetPasswordInput{
+		Token:       req.Token,
+		NewPassword: req.NewPassword,
+	}
+
+	if err := c.authUseCase.ResetPassword(ctx.Request().Context(), input); err != nil {
+		if err.Error() == "無効または期限切れのトークンです" || err.Error() == "無効なトークンです" {
+			return ctx.JSON(http.StatusBadRequest, NewErrorResponse(ctx, ErrorCodeBadRequest, err.Error(), nil))
+		}
+		return ctx.JSON(http.StatusInternalServerError, NewErrorResponse(ctx, ErrorCodeInternalServer, "パスワードリセットに失敗しました", err.Error()))
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]string{
+		"message": "パスワードをリセットしました",
+	})
+}

--- a/backend/infrastructure/web/controllers/auth_controller_test.go
+++ b/backend/infrastructure/web/controllers/auth_controller_test.go
@@ -110,6 +110,16 @@ func (m *MockAuthUseCase) Get2FAStatus(ctx context.Context, userID string) (*use
 	return args.Get(0).(*usecases.Get2FAStatusOutput), args.Error(1)
 }
 
+func (m *MockAuthUseCase) ForgotPassword(ctx context.Context, input usecases.ForgotPasswordInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *MockAuthUseCase) ResetPassword(ctx context.Context, input usecases.ResetPasswordInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
 // newTestServerConfig creates a minimal ServerConfig for tests
 func newTestServerConfig() *config.ServerConfig {
 	return &config.ServerConfig{

--- a/backend/infrastructure/web/routes.go
+++ b/backend/infrastructure/web/routes.go
@@ -89,10 +89,12 @@ func setupAuthRoutes(api *echo.Group, controller *controllers.AuthController, de
 	// 認証レートリミッターをグループに適用（ブルートフォース対策）
 	auth.Use(authRateLimiter)
 
-	auth.POST("/register", controller.Register) // POST /api/auth/register
-	auth.POST("/login", controller.Login)       // POST /api/auth/login
-	auth.POST("/refresh", controller.Refresh)   // POST /api/auth/refresh
-	auth.POST("/logout", controller.Logout)     // POST /api/auth/logout
+	auth.POST("/register", controller.Register)              // POST /api/auth/register
+	auth.POST("/login", controller.Login)                    // POST /api/auth/login
+	auth.POST("/refresh", controller.Refresh)                // POST /api/auth/refresh
+	auth.POST("/logout", controller.Logout)                  // POST /api/auth/logout
+	auth.POST("/forgot-password", controller.ForgotPassword) // POST /api/auth/forgot-password
+	auth.POST("/reset-password", controller.ResetPassword)   // POST /api/auth/reset-password
 
 	// GitHub OAuth routes with middleware (Issue: #67)
 	githubOAuth := auth.Group("/github")

--- a/backend/infrastructure/web/server.go
+++ b/backend/infrastructure/web/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/financial-planning-calculator/backend/config"
 	"github.com/financial-planning-calculator/backend/domain/repositories"
 	"github.com/financial-planning-calculator/backend/domain/services"
+	infraemail "github.com/financial-planning-calculator/backend/infrastructure/email"
 	"github.com/financial-planning-calculator/backend/infrastructure/web/controllers"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/labstack/echo/v4"
@@ -16,6 +17,9 @@ import (
 type ServerDependencies struct {
 	// Repositories
 	UserRepo               repositories.UserRepository
+	PasswordResetTokenRepo repositories.PasswordResetTokenRepository
+	// Email service
+	EmailService           infraemail.EmailService
 	RefreshTokenRepo       repositories.RefreshTokenRepository
 	WebAuthnCredentialRepo repositories.WebAuthnCredentialRepository
 	FinancialPlanRepo      repositories.FinancialPlanRepository
@@ -49,6 +53,8 @@ func NewControllers(deps *ServerDependencies) *Controllers {
 	authUseCase := usecases.NewAuthUseCase(
 		deps.UserRepo,
 		deps.RefreshTokenRepo,
+		deps.PasswordResetTokenRepo,
+		deps.EmailService,
 		deps.JWTSecret,
 		deps.JWTExpiration,
 		deps.RefreshTokenExpiration,

--- a/backend/main.go
+++ b/backend/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/financial-planning-calculator/backend/config"
 	"github.com/financial-planning-calculator/backend/domain/services"
 	"github.com/financial-planning-calculator/backend/infrastructure/monitoring"
+	"github.com/financial-planning-calculator/backend/infrastructure/email"
 	"github.com/financial-planning-calculator/backend/infrastructure/repositories"
 	"github.com/financial-planning-calculator/backend/infrastructure/web"
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -109,6 +110,7 @@ func initializeDependencies() *web.ServerDependencies {
 
 	userRepo := repoFactory.NewUserRepository()
 	refreshTokenRepo := repoFactory.NewRefreshTokenRepository()
+	passwordResetTokenRepo := repoFactory.NewPasswordResetTokenRepository()
 	webAuthnCredentialRepo := repoFactory.NewWebAuthnCredentialRepository()
 	financialPlanRepo := repoFactory.NewFinancialPlanRepository()
 	goalRepo := repoFactory.NewGoalRepository()
@@ -120,6 +122,15 @@ func initializeDependencies() *web.ServerDependencies {
 	// Load server config for JWT settings
 	serverCfg := config.LoadServerConfig()
 
+	// Initialize email service
+	emailService := email.NewEmailService(
+		serverCfg.SMTPHost,
+		serverCfg.SMTPPort,
+		serverCfg.SMTPUser,
+		serverCfg.SMTPPassword,
+		serverCfg.SMTPFrom,
+	)
+
 	// Initialize WebAuthn
 	webAuthn, err := initializeWebAuthn(serverCfg)
 	if err != nil {
@@ -129,6 +140,8 @@ func initializeDependencies() *web.ServerDependencies {
 	return &web.ServerDependencies{
 		UserRepo:                 userRepo,
 		RefreshTokenRepo:         refreshTokenRepo,
+		PasswordResetTokenRepo:   passwordResetTokenRepo,
+		EmailService:             emailService,
 		WebAuthnCredentialRepo:   webAuthnCredentialRepo,
 		FinancialPlanRepo:        financialPlanRepo,
 		GoalRepo:                 goalRepo,


### PR DESCRIPTION
## Summary
- パスワードリセット用の2つのAPIエンドポイントを実装（`POST /api/auth/forgot-password`, `POST /api/auth/reset-password`）
- トークンはSHA-256ハッシュでDB保存、30分有効、1回限り使用のセキュアな設計
- メール送信はSMTP対応＋開発用ログ出力フォールバック付き

## 新規ファイル
- `password_reset_tokens` テーブルのマイグレーション
- `PasswordResetToken` エンティティ + リポジトリ（ドメイン層）
- PostgreSQL リポジトリ実装（インフラ層）
- `EmailService` インターフェース + SMTP/ログ実装

## セキュリティ
- ユーザー列挙対策: 存在しないメールでも200を返す
- トークンは平文保存せずSHA-256ハッシュのみDB保存
- 30分で期限切れ、使用済みトークンは再利用不可

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./...` 成功（既存のrepository統合テスト失敗はpre-existing）
- [ ] Docker環境でマイグレーション適用確認
- [ ] `curl` で forgot-password → ログ確認 → reset-password の一連フロー確認

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)