### PR TITLE
feat(frontend): セキュリティ設定ページへのナビゲーション導線を追加

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -425,6 +425,19 @@ export default function DashboardPage() {
                   </div>
                 </div>
               </Link>
+
+              <Link
+                href="/settings/security"
+                className="block w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-300 hover:bg-primary-50 dark:hover:bg-primary-900/30 transition-colors"
+              >
+                <div className="flex items-center space-x-3">
+                  <span className="text-xl">🔒</span>
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">セキュリティ設定</p>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">2段階認証の管理</p>
+                  </div>
+                </div>
+              </Link>
             </div>
           </div>
 

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -66,6 +66,18 @@ const Navigation = () => {
                 <span className="text-sm text-gray-600 dark:text-gray-300">
                   {user?.email}
                 </span>
+                <Link
+                  href="/settings/security"
+                  className={`flex items-center space-x-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    pathname === '/settings/security'
+                      ? 'bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700'
+                  }`}
+                  title="セキュリティ設定"
+                >
+                  <span>🔒</span>
+                  <span>セキュリティ</span>
+                </Link>
                 <button
                   onClick={logout}
                   className="flex items-center space-x-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700"
@@ -148,6 +160,17 @@ const Navigation = () => {
               <div className="px-3 py-2 text-sm text-gray-600 dark:text-gray-300 border-t border-gray-200 dark:border-gray-700 mt-2 pt-2">
                 {user?.email}
               </div>
+              <Link
+                href="/settings/security"
+                className={`flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors w-full ${
+                  pathname === '/settings/security'
+                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700'
+                }`}
+              >
+                <span>🔒</span>
+                <span>セキュリティ設定</span>
+              </Link>
               <button
                 onClick={logout}
                 className="flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700 w-full"


### PR DESCRIPTION
## Summary
- ナビゲーションバーに認証済みユーザー向け「セキュリティ」リンクを追加（デスクトップ・モバイル対応）
- ダッシュボードのクイックアクションに「セキュリティ設定」カードを追加

## Test plan
- [ ] 認証済みユーザーでナビゲーションバーに「セキュリティ」リンクが表示される
- [ ] モバイルメニューにも「セキュリティ設定」リンクが表示される
- [ ] ダッシュボードのクイックアクションから `/settings/security` に遷移できる
- [ ] セキュリティ設定ページで 2FA の有効/無効が操作できる
- [ ] 未認証ユーザーにはセキュリティリンクが表示されない

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)