### PR TITLE
fix(frontend): 計算ページのハードコードされたユーザーIDを修正

### DIFF
--- a/frontend/src/app/calculations/__tests__/page.test.tsx
+++ b/frontend/src/app/calculations/__tests__/page.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import CalculationsPage from '../page';
+
+// useUser フックをモック
+jest.mock('@/lib/hooks/useUser', () => ({
+  useUser: jest.fn(),
+}));
+
+// 重いコンポーネントをモック
+jest.mock('@/components', () => ({
+  AssetProjectionCalculator: () => <div data-testid="asset-projection-calculator" />,
+  RetirementCalculator: () => <div data-testid="retirement-calculator" />,
+  EmergencyFundCalculator: () => <div data-testid="emergency-fund-calculator" />,
+}));
+
+jest.mock('@/components/AssetProjectionChart', () => ({
+  __esModule: true,
+  default: () => <div data-testid="asset-projection-chart" />,
+}));
+
+jest.mock('@/lib/utils/projections', () => ({
+  generateAssetProjections: jest.fn(() => Array(31).fill({ total_assets: 0 })),
+}));
+
+jest.mock('@/lib/utils/currency', () => ({
+  formatCurrency: (v: number) => `¥${v.toLocaleString()}`,
+}));
+
+import { useUser } from '@/lib/hooks/useUser';
+
+const mockUseUser = useUser as jest.MockedFunction<typeof useUser>;
+
+describe('CalculationsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ローディング中はローディングメッセージを表示する', () => {
+    mockUseUser.mockReturnValue({
+      userId: null,
+      email: null,
+      loading: true,
+      clearUser: jest.fn(),
+      isGuest: false,
+    });
+
+    render(<CalculationsPage />);
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('未ログイン時はエラーメッセージを表示する', () => {
+    mockUseUser.mockReturnValue({
+      userId: null,
+      email: null,
+      loading: false,
+      clearUser: jest.fn(),
+      isGuest: false,
+    });
+
+    render(<CalculationsPage />);
+
+    expect(screen.getByText('ログインが必要です')).toBeInTheDocument();
+    expect(screen.getByText('計算機能を使用するにはログインしてください。')).toBeInTheDocument();
+  });
+
+  it('ログイン済みの場合は計算メニューを表示する', () => {
+    mockUseUser.mockReturnValue({
+      userId: 'test-user-id',
+      email: 'test@example.com',
+      loading: false,
+      clearUser: jest.fn(),
+      isGuest: false,
+    });
+
+    render(<CalculationsPage />);
+
+    expect(screen.getByText('財務計算機')).toBeInTheDocument();
+    expect(screen.getByText('資産推移シミュレーション')).toBeInTheDocument();
+    expect(screen.getByText('老後資金計算')).toBeInTheDocument();
+    expect(screen.getByText('緊急資金計算')).toBeInTheDocument();
+  });
+
+  it('ゲストモードの場合も計算メニューを表示する', () => {
+    mockUseUser.mockReturnValue({
+      userId: 'guest',
+      email: null,
+      loading: false,
+      clearUser: jest.fn(),
+      isGuest: true,
+    });
+
+    render(<CalculationsPage />);
+
+    expect(screen.getByText('財務計算機')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/calculations/page.tsx
+++ b/frontend/src/app/calculations/page.tsx
@@ -9,6 +9,7 @@ import {
 import AssetProjectionChart from '@/components/AssetProjectionChart';
 import { generateAssetProjections } from '@/lib/utils/projections';
 import { formatCurrency } from '@/lib/utils/currency';
+import { useUser } from '@/lib/hooks/useUser';
 
 type CalculatorView = 'menu' | 'asset-projection' | 'retirement' | 'emergency';
 
@@ -21,7 +22,7 @@ const SAMPLE_PROJECTION_YEARS = 30;
 
 export default function CalculationsPage() {
   const [activeView, setActiveView] = useState<CalculatorView>('menu');
-  const userId = 'user-001'; // TODO: 実際のユーザーIDを取得
+  const { userId, loading } = useUser();
 
   // サンプル資産推移データを生成（30年間）
   const sampleProjections = generateAssetProjections(
@@ -31,6 +32,25 @@ export default function CalculationsPage() {
     SAMPLE_INVESTMENT_RETURN,
     SAMPLE_INFLATION_RATE
   );
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-7xl flex justify-center items-center min-h-[200px]">
+        <p className="text-gray-500 dark:text-gray-400">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!userId) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-7xl">
+        <div className="card text-center py-12">
+          <p className="text-gray-700 dark:text-gray-300 text-lg mb-2">ログインが必要です</p>
+          <p className="text-gray-500 dark:text-gray-400 text-sm">計算機能を使用するにはログインしてください。</p>
+        </div>
+      </div>
+    );
+  }
 
   if (activeView === 'asset-projection') {
     return (


### PR DESCRIPTION
## 概要

`calculations/page.tsx` の TODO を解消し、実際のログインユーザーIDを API に渡せるようにします。

## 変更内容

- `useUser()` フックを使って実際のログインユーザーIDを取得
- ローディング中はローディングメッセージを表示
- 未ログイン時（`userId` が null）はエラーメッセージを表示
- テストケースを追加（ローディング / 未ログイン / ログイン済み / ゲストモード）

## 受け入れ基準

- [x] ハードコードされた `user-001` が削除されている
- [x] ログインユーザーのIDが正しく使われる
- [x] 未ログイン時はエラーメッセージを表示
- [x] テストでモックユーザーを使ったテストケースが追加されている

## テスト結果

```
PASS  src/app/calculations/__tests__/page.test.tsx
  ✓ ローディング中はローディングメッセージを表示する
  ✓ 未ログイン時はエラーメッセージを表示する
  ✓ ログイン済みの場合は計算メニューを表示する
  ✓ ゲストモードの場合も計算メニューを表示する
```

Closes #149
