### PR TITLE
fix(frontend): ログインボタンがローディングのまま止まらないバグを修正

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -44,7 +44,7 @@ const nextConfig = {
       {
         source: '/api/:path*',
         destination: process.env.NEXT_PUBLIC_API_URL
-          ? `${process.env.NEXT_PUBLIC_API_URL}/:path*`
+          ? `${process.env.NEXT_PUBLIC_API_URL}/api/:path*`
           : 'http://localhost:8080/api/:path*',
       },
     ];

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -125,7 +125,7 @@ export default function LoginPage() {
             fullWidth
             variant="secondary"
             onClick={() => {
-              window.location.href = `${process.env.NEXT_PUBLIC_API_URL || '/api'}/auth/github`;
+              window.location.href = '/api/auth/github';
             }}
             disabled={isLoading}
             className="flex items-center justify-center gap-2"

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -5,7 +5,7 @@ import { LoadingSpinner } from '@/components';
 import AssetProjectionChart from '@/components/AssetProjectionChart';
 import { generateAssetProjections } from '@/lib/utils/projections';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+const API_BASE_URL = '/api';
 
 // Sample data constants for report preview
 const SAMPLE_INITIAL_ASSETS = 1500000; // ¥1,500,000

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -22,8 +22,8 @@ import type {
   RegenerateBackupCodesResponse,
 } from '@/types/api';
 
-// API ベースURL
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+// API ベースURL（CSP connect-src 'self' に準拠するため相対パスに固定）
+const API_BASE_URL = '/api';
 
 // リフレッシュ中フラグ（複数のリクエストが同時にリフレッシュするのを防ぐ）
 let isRefreshing = false;

--- a/frontend/src/lib/contexts/AuthContext.tsx
+++ b/frontend/src/lib/contexts/AuthContext.tsx
@@ -38,8 +38,8 @@ const USER_KEY = 'auth_user';
 // 2FA用の一時トークンキー
 const TEMP_TOKEN_KEY = 'auth_token';
 
-// API ベースURL
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+// API ベースURL（CSP connect-src 'self' に準拠するため相対パスに固定）
+const API_BASE_URL = '/api';
 
 interface AuthProviderProps {
   children: ReactNode;
@@ -93,6 +93,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setIsLoading(true);
     setError(null);
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
     try {
       const response = await fetch(`${API_BASE_URL}/auth/login`, {
         method: 'POST',
@@ -101,6 +104,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         },
         body: JSON.stringify({ email, password }),
         credentials: 'include', // Cookieを送受信
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -112,7 +116,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       const data: AuthResponse = await response.json();
-      
+
       // リフレッシュトークンが空の場合は2FA検証が必要
       // 仮トークンはCookieで自動的に設定されるため、localStorageへの保存は不要
       if (!data.refresh_token) {
@@ -124,10 +128,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
         router.push('/dashboard');
       }
     } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        const message = 'ログインタイムアウト：ネットワーク接続を確認してください';
+        setError(message);
+        throw new Error(message);
+      }
       const message = e instanceof Error ? e.message : 'ログインに失敗しました';
       setError(message);
       throw e;
     } finally {
+      clearTimeout(timeoutId);
       setIsLoading(false);
     }
   }, [router, saveAuthData]);
@@ -137,6 +147,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setIsLoading(true);
     setError(null);
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
     try {
       const response = await fetch(`${API_BASE_URL}/auth/register`, {
         method: 'POST',
@@ -145,6 +158,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         },
         body: JSON.stringify({ email, password }),
         credentials: 'include', // Cookieを送受信
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -159,10 +173,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
       saveAuthData(data);
       router.push('/dashboard');
     } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        const message = '登録タイムアウト：ネットワーク接続を確認してください';
+        setError(message);
+        throw new Error(message);
+      }
       const message = e instanceof Error ? e.message : '登録に失敗しました';
       setError(message);
       throw e;
     } finally {
+      clearTimeout(timeoutId);
       setIsLoading(false);
     }
   }, [router, saveAuthData]);

--- a/frontend/src/lib/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/lib/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,222 @@
+import React, { ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../AuthContext';
+
+// next/navigation モック
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+// テスト用ラッパー
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
+
+// ログイン成功レスポンス
+const mockLoginSuccessResponse = {
+  user_id: 'user_123',
+  email: 'test@example.com',
+  token: 'mock-token',
+  refresh_token: 'mock-refresh-token',
+  expires_at: '2026-12-31T00:00:00Z',
+};
+
+describe('AuthContext - login 関数', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset();
+    // localStorage.getItem は初期化時に null を返す（未ログイン状態）
+    (window.localStorage.getItem as jest.Mock).mockReturnValue(null);
+  });
+
+  describe('正常系', () => {
+    it('ログイン成功時に isLoading が最終的に false になる', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLoginSuccessResponse,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      // 初期化完了を待つ（useEffect で setIsLoading(false) が呼ばれる）
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.login('test@example.com', 'password123');
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('ログイン成功時に router.push が呼ばれる', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLoginSuccessResponse,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.login('test@example.com', 'password123');
+      });
+
+      expect(mockPush).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  describe('エラー系', () => {
+    it('fetch が失敗した場合に isLoading が false になる', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error('Network error')
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        try {
+          await result.current.login('test@example.com', 'password123');
+        } catch {
+          // エラーがスローされることを期待
+        }
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('fetch が失敗した場合にエラーメッセージが設定される', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error('Network error')
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        try {
+          await result.current.login('test@example.com', 'password123');
+        } catch {
+          // エラーがスローされることを期待
+        }
+      });
+
+      expect(result.current.error).toBe('Network error');
+    });
+
+    it('401レスポンス時に isLoading が false になり、適切なエラーメッセージが設定される', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'Unauthorized' }),
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        try {
+          await result.current.login('test@example.com', 'wrong-password');
+        } catch {
+          // エラーがスローされることを期待
+        }
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBe(
+        'メールアドレスまたはパスワードが正しくありません'
+      );
+    });
+  });
+
+  describe('タイムアウト系', () => {
+    it('fetch がタイムアウト（AbortError）した場合に isLoading が false になる', async () => {
+      const abortError = new DOMException('The operation was aborted.', 'AbortError');
+      (global.fetch as jest.Mock).mockRejectedValueOnce(abortError);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        try {
+          await result.current.login('test@example.com', 'password123');
+        } catch {
+          // タイムアウトエラーがスローされることを期待
+        }
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('fetch がタイムアウト（AbortError）した場合にタイムアウトエラーメッセージが設定される', async () => {
+      const abortError = new DOMException('The operation was aborted.', 'AbortError');
+      (global.fetch as jest.Mock).mockRejectedValueOnce(abortError);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        try {
+          await result.current.login('test@example.com', 'password123');
+        } catch {
+          // タイムアウトエラーがスローされることを期待
+        }
+      });
+
+      // タイムアウト時はタイムアウト関連のエラーメッセージが設定される（修正後の実装を期待）
+      expect(result.current.error).toBeTruthy();
+      expect(result.current.error).toMatch(/タイムアウト|接続がタイムアウト|リクエストがタイムアウト/);
+    });
+  });
+
+  describe('API_BASE_URL 確認', () => {
+    it('login 時の fetch が相対パス /api/auth/login を使っている（絶対 URL を使っていない）', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLoginSuccessResponse,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.login('test@example.com', 'password123');
+      });
+
+      // fetch が呼ばれた URL を確認
+      expect(global.fetch).toHaveBeenCalled();
+      const fetchCallUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+      // 相対パスであること（絶対 URL ではないこと）
+      expect(fetchCallUrl).toBe('/api/auth/login');
+      expect(fetchCallUrl).not.toMatch(/^https?:\/\//);
+    });
+  });
+});

--- a/frontend/src/lib/integration-utils.ts
+++ b/frontend/src/lib/integration-utils.ts
@@ -61,7 +61,7 @@ export async function checkAPIHealth(): Promise<{
   details?: any;
 }> {
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL || '/api';
+    const baseUrl = '/api';
     const healthUrl = `${baseUrl}/health/detailed`;
     
     const response = await fetch(healthUrl, {
@@ -96,7 +96,7 @@ export async function checkAPIHealth(): Promise<{
 // Check API readiness
 export async function checkAPIReadiness(): Promise<boolean> {
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL || '/api';
+    const baseUrl = '/api';
     const readyUrl = `${baseUrl}/ready`;
     
     const response = await fetch(readyUrl);


### PR DESCRIPTION
- API_BASE_URLを'/api'に固定しCSP違反によるfetchハングを防止
- login/register関数にAbortControllerタイムアウト（10秒）を追加
- next.config.jsのrewrites.destinationに'/api'が欠落していたバグを修正
- api-client.ts/integration-utils.ts/login/page.tsxも同様に修正