### PR TITLE
chore(render): Neon DB向けにマイグレーション自動実行を設定

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,3 @@
-databases:
-  - name: financial-planning-db
-    plan: free
-    region: oregon
-
 services:
   # Backend API Service
   - type: web
@@ -14,27 +9,18 @@ services:
     plan: free
     region: oregon
     healthCheckPath: /health
+    preDeployCommand: ./migrate
     envVars:
       - key: DB_HOST
-        fromDatabase:
-          name: financial-planning-db
-          property: host
+        sync: false
       - key: DB_PORT
-        fromDatabase:
-          name: financial-planning-db
-          property: port
+        sync: false
       - key: DB_USER
-        fromDatabase:
-          name: financial-planning-db
-          property: user
+        sync: false
       - key: DB_PASSWORD
-        fromDatabase:
-          name: financial-planning-db
-          property: password
+        sync: false
       - key: DB_NAME
-        fromDatabase:
-          name: financial-planning-db
-          property: database
+        sync: false
       - key: DB_SSLMODE
         value: require
       - key: GIN_MODE


### PR DESCRIPTION
## Summary
- Render管理のPostgreSQLを廃止し、NeonへDB接続を切り替え
- `preDeployCommand: ./migrate` を追加し、デプロイ前にマイグレーションを自動実行
- DB接続環境変数を `fromDatabase` から `sync: false`（手動設定）に変更

## After merge
Renderダッシュボードで以下の環境変数をNeonの値に手動設定してください：
- `DB_HOST`
- `DB_PORT`
- `DB_USER`
- `DB_PASSWORD`
- `DB_NAME`

## Test plan
- [ ] Renderダッシュボードで環境変数をNeonの接続情報に設定
- [ ] デプロイ実行し、Pre-Deploy Commandでマイグレーションが走ることを確認
- [ ] アプリが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)