### PR TITLE
fix(render): APIプロキシとマイグレーション自動実行の設定

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const backendUrl = process.env.BACKEND_URL;
+
+  if (!backendUrl) {
+    // BACKEND_URL未設定の場合（ローカル開発時）はリライトしない
+    // next.config.js の rewrites が localhost:8080 にフォールバック
+    return NextResponse.next();
+  }
+
+  // /api/* リクエストをバックエンドにリライト
+  const url = new URL(request.nextUrl.pathname + request.nextUrl.search, backendUrl);
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};

--- a/render.yaml
+++ b/render.yaml
@@ -44,6 +44,8 @@ services:
     envVars:
       - key: NEXT_PUBLIC_API_URL
         sync: false
+      - key: BACKEND_URL
+        sync: false
       - key: NODE_ENV
         value: production
     buildFilter:


### PR DESCRIPTION
## Summary
- Neon DB向けにpre-deployコマンドでマイグレーション自動実行を設定
- Next.js middlewareを追加し、Render上でAPIリクエストがlocalhost:8080にフォールバックする問題を修正
- `BACKEND_URL` 環境変数（ランタイム）を使用してバックエンドサービスにリライト

## 背景
Next.js の `rewrites()` はビルド時に評価されるため、Docker環境では `NEXT_PUBLIC_API_URL` が未設定となり `localhost:8080` にフォールバックしていた。`NEXT_PUBLIC_` プレフィックスなしの `BACKEND_URL` をランタイムで読み取る middleware に切り替え。

## デプロイ後の作業
- Render ダッシュボードで frontend サービスに `BACKEND_URL` = `https://financial-planning-backend-5n5o.onrender.com` を設定

## Test plan
- [ ] ローカル開発環境で `BACKEND_URL` 未設定時に既存の rewrites フォールバックが動作すること
- [ ] Render デプロイ後に `/api/auth/register` 等のリクエストがバックエンドに正しくプロキシされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)