### PR TITLE
chore(ci): CIキャッシュ最適化・冗長ステップ削除・バッジ安定化 #162

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -20,7 +20,8 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm' # npmキャッシュを有効化
+        cache: 'npm'
+        cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,29 +31,13 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       
-      - name: Clean module cache
-        working-directory: ./backend
-        run: go clean -modcache || true
-      
-      - name: Go Mod Tidy
-        working-directory: ./backend
-        run: go mod tidy
-      
-      - name: Verify dependencies
-        working-directory: ./backend
-        run: go mod verify
-      
       - name: Build
         working-directory: ./backend
         run: go build -v ./...
       
-      - name: Run tests
-        working-directory: ./backend
-        run: go test -v -race -timeout 30s ./...
-      
       - name: Run tests with coverage
         working-directory: ./backend
-        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -v -race -timeout 30s -coverprofile=coverage.out -covermode=atomic ./...
       
       - name: Upload coverage to Codecov
         if: matrix.go-version == '1.21'

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ A modern web application to visualize your financial future and plan for retirem
 
 ## CI ステータス
 
-[![Lint](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/lint.yml/badge.svg)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/lint.yml)
-[![Test](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/test.yml/badge.svg)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/test.yml)
-[![E2E Tests](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/e2e-tests.yml)
-[![PR Check](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/pr-check.yml/badge.svg)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/pr-check.yml)
+[![Lint](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/lint.yml)
+[![Test](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/test.yml)
+[![E2E Tests](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/e2e-tests.yml/badge.svg?branch=main)](https://github.com/zakisanbaiman/financial-planning-calculator/actions/workflows/e2e-tests.yml)
 
 ## 🎯 主要機能
 


### PR DESCRIPTION
## Summary

- `setup-node` に `cache-dependency-path` を追加し、正しい `package-lock.json` を参照するよう修正
- `test.yml` から `go clean -modcache` / `go mod tidy` / `go mod verify` の冗長ステップを削除（`setup-go` アクションがキャッシュ済み）
- `go test` の二重実行を統合（`-timeout` と `-coverprofile` を同一ステップに）
- READMEのCIバッジに `?branch=main` を追加してmainブランチの状態を正確に表示
- `PR Check` バッジを削除（`pull_request` イベント専用で常時表示に不適）

## 改善効果

| 項目 | Before | After |
|------|--------|-------|
| バックエンドテストのGoモジュールキャッシュ | 毎回破棄 (`go clean -modcache`) | キャッシュ活用 |
| バックエンドテストのステップ数 | 6ステップ | 3ステップ |
| go test の実行回数 | 2回 | 1回 |
| CIバッジの表示対象 | 最新実行（ブランチ問わず） | mainブランチの実行のみ |

## Test plan

- [ ] CI（Lint / Test / E2E）がパスすることを確認
- [ ] READMEのバッジがmainブランチのステータスを表示することを確認

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)