### PR TITLE
feat(frontend): Google Analytics (GA4) を追加 #165

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,6 @@ NEXT_PUBLIC_API_URL=http://localhost:8080/api
 
 # 環境設定
 NODE_ENV=development
+
+# Google Analytics
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",
+        "@next/third-parties": "^16.2.1",
         "chart.js": "^4.4.0",
         "critters": "^0.0.25",
         "next": "14.2.35",
@@ -1823,6 +1824,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.1.tgz",
+      "integrity": "sha512-XyeT9WVBUdVXMrKFz0wTSrMc+O5JN2B08yU7JpK8YJiP/qBgc3q1kIfjop/pdnhT4W4oLjwXaqrMh7uWaoYILQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9755,6 +9769,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.2",
+    "@next/third-parties": "^16.2.1",
     "chart.js": "^4.4.0",
     "critters": "^0.0.25",
     "next": "14.2.35",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Cormorant_Garamond, Source_Sans_3, JetBrains_Mono } from 'next/font/google';
+import { GoogleAnalytics } from '@next/third-parties/google';
 import './globals.css';
 import Navigation from '@/components/Navigation';
 import Tutorial from '@/components/Tutorial';
@@ -78,6 +79,9 @@ export default function RootLayout({
           <Tutorial />
         </AppProviders>
       </body>
+      {process.env.NEXT_PUBLIC_GA_ID && (
+        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+      )}
     </html>
   );
 }


### PR DESCRIPTION
## Summary

- `@next/third-parties/google` の `GoogleAnalytics` コンポーネントを導入
- `layout.tsx` に GA4 タグを追加（`NEXT_PUBLIC_GA_ID` 未設定時はレンダリングをスキップ）
- `.env.example` に `NEXT_PUBLIC_GA_ID` を追記
- Railway の `financial-planning-frontend` サービスに環境変数を設定済み

## Test plan

- [ ] ローカルで `.env.local` に `NEXT_PUBLIC_GA_ID` を設定してビルド確認
- [ ] ブラウザの DevTools でネットワークタブに `google-analytics.com` へのリクエストが発生することを確認
- [ ] GA4 管理画面の「リアルタイム」でアクセスが計測されることを確認

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)