### PR TITLE
fix(frontend): SSOボタンのダークモード表示を修正

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -25,7 +25,7 @@ const Button: React.FC<ButtonProps> = ({
 
   const variantClasses = {
     primary: 'bg-primary-500 hover:bg-primary-600 text-white focus:ring-primary-500',
-    secondary: 'bg-gray-200 hover:bg-gray-300 text-gray-800 dark:text-gray-200 focus:ring-gray-500',
+    secondary: 'bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200 focus:ring-gray-500',
     success: 'bg-success-500 hover:bg-success-600 text-white focus:ring-success-500',
     warning: 'bg-warning-500 hover:bg-warning-600 text-white focus:ring-warning-500',
     error: 'bg-error-500 hover:bg-error-600 text-white focus:ring-error-500',


### PR DESCRIPTION
## 問題

ダークモード時、ログインページの「GitHubでログイン」ボタン（`secondary` バリアント）が白背景で表示され、テキストがほぼ見えない状態だった。

## 原因

`Button` コンポーネントの `secondary` バリアントに `dark:` 対応の背景色が指定されていなかった。

```
// 修正前
secondary: 'bg-gray-200 hover:bg-gray-300 text-gray-800 dark:text-gray-200 ...'
//                                                       ↑ テキスト色は dark: 対応済みだが背景色が未対応

// 修正後
secondary: 'bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200 ...'
```

## 変更内容

- `frontend/src/components/Button.tsx`: `secondary` バリアントに `dark:bg-gray-700` / `dark:hover:bg-gray-600` を追加

## 影響範囲

`secondary` バリアントを使用するすべてのボタンがダークモードで正しく表示されるようになる。

## Test plan

- [ ] ダークモードでログインページを開き、GitHubログインボタンが視認できることを確認
- [ ] ライトモードでの表示が変わっていないことを確認
- [ ] `secondary` バリアントを使用する他のページ（設定画面など）でも表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)