### PR TITLE
feat(infra): Grafanaにアラートルールを設定する #146

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -16,9 +16,27 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.enable-lifecycle'
     networks:
       - monitoring
       - financial_planning_network
+    restart: unless-stopped
+
+  # Alertmanager（アラート通知管理）
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: financial-planning-alertmanager
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+      - alertmanager-data:/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+      - '--web.external-url=http://localhost:9093'
+    networks:
+      - monitoring
     restart: unless-stopped
 
   # Loki（ログ集約）
@@ -60,14 +78,18 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_UNIFIED_ALERTING_ENABLED=true
+      - GF_ALERTING_ENABLED=false
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
       - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./monitoring/grafana/provisioning/alerting:/etc/grafana/provisioning/alerting
       - ./monitoring/grafana-dashboard.json:/etc/grafana/provisioning/dashboards/json/financial-planning.json
     depends_on:
       - prometheus
       - loki
+      - alertmanager
     networks:
       - monitoring
     restart: unless-stopped
@@ -76,6 +98,7 @@ volumes:
   prometheus-data:
   grafana-data:
   loki-data:
+  alertmanager-data:
 
 networks:
   monitoring:

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,71 @@
+# Prometheusアラートルール定義
+# Issue #146: Grafanaにアラートルールを設定する
+
+groups:
+  - name: financial_planning_calculator_alerts
+    interval: 1m
+    rules:
+
+      # HTTPエラーレートが5%を超えた状態が5分以上続く場合
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{status=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total[5m]))
+          ) * 100 > 5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "高エラーレートを検知"
+          description: "HTTPエラーレートが {{ $value | printf \"%.2f\" }}% (閾値: 5%) を超えています。"
+          runbook_url: "https://github.com/zakisanbaiman/financial-planning-calculator/wiki/Runbook-HighErrorRate"
+
+      # P99レスポンスタイムが2秒を超えた場合
+      - alert: SlowResponseTime
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 2
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P99レスポンスタイムが遅延"
+          description: "P99レスポンスタイムが {{ $value | printf \"%.2f\" }}秒 (閾値: 2秒) を超えています。"
+          runbook_url: "https://github.com/zakisanbaiman/financial-planning-calculator/wiki/Runbook-SlowResponseTime"
+
+      # DBアクティブ接続数が80を超えた場合（最大接続数100想定）
+      - alert: DatabaseConnectionHigh
+        expr: database_connections_active > 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DB接続数が高水準"
+          description: "アクティブなDB接続数が {{ $value }} (閾値: 80) を超えています。"
+          runbook_url: "https://github.com/zakisanbaiman/financial-planning-calculator/wiki/Runbook-DatabaseConnectionHigh"
+
+      # Prometheusがターゲットのscrapeに失敗した場合
+      - alert: ServiceDown
+        expr: up{job="financial-planning-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "サービスがダウン"
+          description: "financial-planning-api ({{ $labels.instance }}) のヘルスチェックが失敗しています。"
+          runbook_url: "https://github.com/zakisanbaiman/financial-planning-calculator/wiki/Runbook-ServiceDown"
+
+      # プロセスのメモリ使用量が500MBを超えた場合（85%相当の想定値）
+      - alert: HighMemoryUsage
+        expr: process_resident_memory_bytes{job="financial-planning-api"} > 524288000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "メモリ使用率が高水準"
+          description: "メモリ使用量が {{ $value | humanize1024 }}B (閾値: 500MiB) を超えています。"
+          runbook_url: "https://github.com/zakisanbaiman/financial-planning-calculator/wiki/Runbook-HighMemoryUsage"

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,51 @@
+# Alertmanager設定
+# Slack通知のWebhook URLはダミー値（本番環境では実際のURLに差し替えること）
+
+global:
+  resolve_timeout: 5m
+  slack_api_url: 'https://hooks.slack.com/services/DUMMY/DUMMY/DUMMY'
+
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'slack-notifications'
+  routes:
+    - match:
+        severity: critical
+      receiver: 'slack-critical'
+      repeat_interval: 1h
+
+receivers:
+  - name: 'slack-notifications'
+    slack_configs:
+      - channel: '#alerts'
+        send_resolved: true
+        title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *アラート:* {{ .Annotations.summary }}
+          *説明:* {{ .Annotations.description }}
+          *重篤度:* {{ .Labels.severity }}
+          {{ if .Annotations.runbook_url }}*Runbook:* {{ .Annotations.runbook_url }}{{ end }}
+          {{ end }}
+
+  - name: 'slack-critical'
+    slack_configs:
+      - channel: '#alerts-critical'
+        send_resolved: true
+        title: ':rotating_light: [CRITICAL] {{ .CommonLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *{{ .Annotations.summary }}*
+          {{ .Annotations.description }}
+          {{ if .Annotations.runbook_url }}*Runbook:* {{ .Annotations.runbook_url }}{{ end }}
+          {{ end }}
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname']

--- a/monitoring/grafana/provisioning/alerting/alerting.yml
+++ b/monitoring/grafana/provisioning/alerting/alerting.yml
@@ -1,0 +1,33 @@
+# Grafana アラートプロビジョニング (Grafana 9.x+ 形式)
+# Prometheusのアラートルールと重複を避けるため、Grafana Managed Alertsのルールは定義しない。
+# 通知チャンネル（コンタクトポイント）のプロビジョニングのみ行う。
+
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: slack-notifications
+    receivers:
+      - uid: slack-receiver-uid
+        type: slack
+        settings:
+          url: 'https://hooks.slack.com/services/DUMMY/DUMMY/DUMMY'
+          recipient: '#alerts'
+          title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+          text: |
+            {{ range .Alerts }}
+            *{{ .Annotations.summary }}*
+            {{ .Annotations.description }}
+            重篤度: {{ .Labels.severity }}
+            {{ end }}
+        disableResolveMessage: false
+
+policies:
+  - orgId: 1
+    receiver: slack-notifications
+    group_by:
+      - alertname
+      - severity
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 12h

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -18,12 +18,12 @@ scrape_configs:
     scrape_interval: 15s
     scrape_timeout: 10s
 
-# アラートルール（オプション）
-# rule_files:
-#   - 'alert_rules.yml'
+# アラートルール
+rule_files:
+  - 'alert_rules.yml'
 
-# Alertmanager設定（オプション）
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets: ['localhost:9093']
+# Alertmanager設定
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']


### PR DESCRIPTION
- monitoring/alert_rules.yml を新規作成（5つのアラートルール定義）
  - HighErrorRate: 5xxエラーレート > 5% が5分以上
  - SlowResponseTime: P99レスポンスタイム > 2秒
  - DatabaseConnectionHigh: DB接続数 > 80
  - ServiceDown: Prometheusのscrape失敗
  - HighMemoryUsage: メモリ使用量 > 500MB
- monitoring/alertmanager.yml を新規作成（Slack通知設定）
- monitoring/grafana/provisioning/alerting/alerting.yml を新規作成
- monitoring/prometheus.yml: rule_files・alerting セクションを有効化
- docker-compose.monitoring.yml: Alertmanagerサービス追加・Grafanaアラート設定追加