### PR TITLE
fix(frontend): /profile・/calculatorの旧URLを新URLへリダイレクト

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -38,6 +38,14 @@ const nextConfig = {
   // Production source maps (disabled for better performance)
   productionBrowserSourceMaps: false,
 
+  // Redirects for renamed routes
+  async redirects() {
+    return [
+      { source: '/profile', destination: '/financial-data', permanent: true },
+      { source: '/calculator', destination: '/calculations', permanent: true },
+    ];
+  },
+
   // API rewrites for development
   async rewrites() {
     return [


### PR DESCRIPTION
## 概要

closes #195

`/profile` と `/calculator` の旧URLへのアクセスが404になる問題を修正。`next.config.js` に永続リダイレクト（301）を設定した。

## 変更内容

- `/profile` → `/financial-data` (301 Permanent Redirect)
- `/calculator` → `/calculations` (301 Permanent Redirect)

## テスト方法

1. `/profile` にアクセスして `/financial-data` へリダイレクトされることを確認
2. `/calculator` にアクセスして `/calculations` へリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)