### PR TITLE
fix(frontend): CSPヘッダーにGA4ドメインを追加 #198

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -84,14 +84,15 @@ const nextConfig = {
             // CSP: Next.js のハイドレーション用インラインスクリプトと
             // Tailwind CSS のインラインスタイルに対応するため 'unsafe-inline' を許可
             // connect-src: /api/* リライト経由でバックエンドAPIに接続するため 'self' のみで十分
+            // GA4: Issue #198 - Google Analytics のビーコン送信・スクリプトロードを許可
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'",
+              "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "font-src 'self'",
-              "connect-src 'self'",
+              "connect-src 'self' https://www.google-analytics.com https://analytics.google.com",
               "frame-ancestors 'none'",
               "base-uri 'self'",
               "form-action 'self'",


### PR DESCRIPTION
## Summary
- `script-src` に `https://www.googletagmanager.com` を追加（GTMスクリプトのロード許可）
- `connect-src` に `https://www.google-analytics.com` と `https://analytics.google.com` を追加（GA4ビーコン送信許可）

## 背景
Issue #165 でGA4を実装したが、CSPヘッダーが更新されていなかったため、GA4のスクリプトロードおよびビーコン送信がブロックされていた。

## Test plan
- [ ] ブラウザのDevToolsでCSP違反エラーが消えていることを確認
- [ ] GA4のリアルタイムレポートでイベントが計測されていることを確認
- [ ] 既存の機能（認証・計算等）に影響がないことを確認

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)