### PR TITLE
fix(backend): /api/health エンドポイントを認証不要で追加する #197

### DIFF
--- a/backend/infrastructure/web/routes.go
+++ b/backend/infrastructure/web/routes.go
@@ -48,6 +48,11 @@ func SetupRoutes(e *echo.Echo, controllers *Controllers, deps *ServerDependencie
 	// API情報エンドポイント
 	api.GET("/", APIInfoHandler)
 
+	// ヘルスチェックエンドポイント（認証不要 - 監視ツール用）
+	api.GET("/health", HealthCheckHandler)
+	api.GET("/health/detailed", IntegrationHealthCheckHandler(deps))
+	api.GET("/ready", APIReadinessHandler(deps))
+
 	// レートリミットステータスエンドポイント（認証不要）
 	api.GET("/rate-limit/status", RateLimitStatusHandler(rateLimitStore))
 

--- a/backend/infrastructure/web/routes_test.go
+++ b/backend/infrastructure/web/routes_test.go
@@ -84,6 +84,7 @@ func TestSetupRoutes(t *testing.T) {
 	}
 
 	assert.Contains(t, routePaths, "/health")
+	assert.Contains(t, routePaths, "/api/health")
 	assert.Contains(t, routePaths, "/api/")
 	assert.Contains(t, routePaths, "/swagger/*")
 	assert.Contains(t, routePaths, "/api/rate-limit/status")


### PR DESCRIPTION
## 概要
- `/api/health`・`/api/health/detailed`・`/api/ready` を認証ミドルウェアのスコープ外（`api` グループ直下）に登録
- これにより Grafana・UptimeRobot などの監視ツールが JWT トークンなしでヘルスチェック可能になる

## 原因
`middleware.ts` が `/api/*` をすべてバックエンドにプロキシするが、バックエンドには `/api/health` ルートが存在せず、認証エラー（401）が返っていた。ルートレベルの `/health` は存在するが、フロントエンド経由では `/api/health` として到達する。

## 変更内容
- `routes.go`: `api` グループに `/health`・`/health/detailed`・`/ready` を認証不要で追加
- `routes_test.go`: `/api/health` ルートの登録確認テストを追加

## テスト
- [x] `TestSetupRoutes` PASS

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)