### PR TITLE
fix(frontend): カスタム404ページを追加する #196

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'ページが見つかりません — FinPlan',
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <p className="font-mono text-ink-400 dark:text-ink-500 text-sm tracking-widest mb-4">404</p>
+      <h1 className="font-display text-3xl text-ink-900 dark:text-ink-100 mb-3">
+        ページが見つかりません
+      </h1>
+      <p className="text-ink-600 dark:text-ink-400 mb-8 max-w-md">
+        お探しのページは存在しないか、移動・削除された可能性があります。
+      </p>
+      <Link
+        href="/"
+        className="px-6 py-2.5 bg-accent-600 hover:bg-accent-700 text-white rounded-lg transition-colors text-sm font-medium"
+      >
+        ホームへ戻る
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

- `app/not-found.tsx` を新規作成し、日本語のカスタム404ページを実装
- `metadata` をエクスポートすることで `<title>` タグの重複（SEO問題）を解消
- アプリのデザインシステム（`ink` / `accent` カラー、`font-display` / `font-mono` フォント）に統一したデザイン

## 変更内容

- `frontend/src/app/not-found.tsx` を追加

## テスト計画

- [ ] 存在しないURLにアクセスして日本語の404ページが表示されることを確認
- [ ] ページタイトルが「ページが見つかりません — FinPlan」になっていることを確認（`<title>` 重複がないこと）
- [ ] 「ホームへ戻る」リンクが `/` に遷移することを確認
- [ ] ダークモードで表示が崩れないことを確認

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)