### PR TITLE
fix(backend): /api/health エンドポイントを認証不要で追加する #197

### DIFF
--- a/backend/infrastructure/web/routes.go
+++ b/backend/infrastructure/web/routes.go
@@ -48,6 +48,11 @@ func SetupRoutes(e *echo.Echo, controllers *Controllers, deps *ServerDependencie
 	// API情報エンドポイント
 	api.GET("/", APIInfoHandler)
 
+	// ヘルスチェックエンドポイント（認証不要 - 監視ツール用）
+	api.GET("/health", HealthCheckHandler)
+	api.GET("/health/detailed", IntegrationHealthCheckHandler(deps))
+	api.GET("/ready", APIReadinessHandler(deps))
+
 	// レートリミットステータスエンドポイント（認証不要）
 	api.GET("/rate-limit/status", RateLimitStatusHandler(rateLimitStore))
 

--- a/backend/infrastructure/web/routes_test.go
+++ b/backend/infrastructure/web/routes_test.go
@@ -84,6 +84,7 @@ func TestSetupRoutes(t *testing.T) {
 	}
 
 	assert.Contains(t, routePaths, "/health")
+	assert.Contains(t, routePaths, "/api/health")
 	assert.Contains(t, routePaths, "/api/")
 	assert.Contains(t, routePaths, "/swagger/*")
 	assert.Contains(t, routePaths, "/api/rate-limit/status")


### PR DESCRIPTION
## 概要

監視ツール（Grafana・UptimeRobot）が JWT トークンなしでヘルスチェックできるよう、`/api/health` 系エンドポイントを認証ミドルウェアのスコープ外に登録する。

## 原因

Next.js の rewrites により `/api/:path*` はバックエンドの `/api/:path*` へプロキシされる。既存の `/health` は認証不要だったが、監視ツールが叩く `/api/health` はバックエンドに存在せず、また `/api` グループには認証ミドルウェアが適用されているため 401 を返していた。

## 変更内容

- `backend/infrastructure/web/routes.go`: `/api/health`・`/api/health/detailed`・`/api/ready` を `api` グループの認証不要ルートとして追加
- `backend/infrastructure/web/routes_test.go`: `/api/health` のルート存在確認テストを追加

## テスト計画

- [ ] `curl https://.../api/health` が認証なしで 200 を返すことを確認
- [ ] `curl https://.../api/health/detailed` が認証なしでアクセスできることを確認
- [ ] 既存の `/health` も引き続き動作することを確認

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)