### PR TITLE
fix: support GA measurement ID aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ make docker-help  # Docker関連のコマンド一覧
 cd frontend
 npm install
 cp .env.example .env.local
+# 必要に応じて NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX を設定
 npm run dev
 ```
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -121,6 +121,7 @@ cp .env.example .env.local
 
 # Edit .env.local
 # NEXT_PUBLIC_API_URL=http://localhost:8080/api
+# NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 
 # Install dependencies
 npm install

--- a/frontend/src/app/__tests__/layout.test.tsx
+++ b/frontend/src/app/__tests__/layout.test.tsx
@@ -18,6 +18,12 @@ jest.mock('next/font/google', () => ({
   })),
 }));
 
+jest.mock('@next/third-parties/google', () => ({
+  GoogleAnalytics: ({ gaId }: { gaId: string }) => (
+    <script data-testid="google-analytics" data-ga-id={gaId} />
+  ),
+}));
+
 // 子コンポーネントをモック
 jest.mock('@/components/Navigation', () => ({
   __esModule: true,
@@ -49,6 +55,21 @@ const mockSourceSans3 = jest.mocked(Source_Sans_3);
 const mockJetBrainsMono = jest.mocked(JetBrains_Mono);
 
 describe('RootLayout', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_GA_ID;
+    delete process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+    delete process.env.GA_MEASUREMENT_ID;
+    delete process.env.GA_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
   describe('next/font/google の設定', () => {
     // フォント関数はモジュールレベルで一度だけ呼ばれる
     // jest.clearAllMocks()（beforeEach で実行）でリセットされる前に引数をキャプチャする
@@ -146,6 +167,38 @@ describe('RootLayout', () => {
       expect(html).toContain('--font-display');
       expect(html).toContain('--font-body');
       expect(html).toContain('--font-mono');
+    });
+  });
+
+  describe('Google Analytics', () => {
+    it('NEXT_PUBLIC_GA_ID が設定されていると Google Analytics を描画する', () => {
+      process.env.NEXT_PUBLIC_GA_ID = 'G-PRIMARY123';
+
+      render(<RootLayout><div /></RootLayout>);
+
+      expect(screen.getByTestId('google-analytics')).toHaveAttribute('data-ga-id', 'G-PRIMARY123');
+    });
+
+    it('NEXT_PUBLIC_GA_MEASUREMENT_ID にも対応する', () => {
+      process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = 'G-MEASURE123';
+
+      render(<RootLayout><div /></RootLayout>);
+
+      expect(screen.getByTestId('google-analytics')).toHaveAttribute('data-ga-id', 'G-MEASURE123');
+    });
+
+    it('GA_MEASUREMENT_ID にも対応する', () => {
+      process.env.GA_MEASUREMENT_ID = 'G-SERVER123';
+
+      render(<RootLayout><div /></RootLayout>);
+
+      expect(screen.getByTestId('google-analytics')).toHaveAttribute('data-ga-id', 'G-SERVER123');
+    });
+
+    it('GA ID が未設定なら Google Analytics を描画しない', () => {
+      render(<RootLayout><div /></RootLayout>);
+
+      expect(screen.queryByTestId('google-analytics')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -50,11 +50,24 @@ export const metadata: Metadata = {
   },
 };
 
+function getGoogleAnalyticsId() {
+  const gaIdCandidates = [
+    process.env.NEXT_PUBLIC_GA_ID,
+    process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
+    process.env.GA_MEASUREMENT_ID,
+    process.env.GA_ID,
+  ];
+
+  return gaIdCandidates.find((value) => typeof value === 'string' && value.trim().length > 0);
+}
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const googleAnalyticsId = getGoogleAnalyticsId();
+
   return (
     <html
       lang="ja"
@@ -97,9 +110,7 @@ export default function RootLayout({
           <Tutorial />
         </AppProviders>
       </body>
-      {process.env.NEXT_PUBLIC_GA_ID && (
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
-      )}
+      {googleAnalyticsId && <GoogleAnalytics gaId={googleAnalyticsId} />}
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- support multiple GA measurement ID environment variable names in the frontend layout
- add layout tests covering configured and missing GA IDs
- document the frontend GA environment variable in setup docs

## Testing
- npm test -- --runInBand frontend/src/app/__tests__/layout.test.tsx
