### PR TITLE
fix(backend): レート制限の閾値緩和・retry_after動的化・X-Forwarded-Forパース修正

### DIFF
--- a/backend/config/server.go
+++ b/backend/config/server.go
@@ -75,7 +75,7 @@ func LoadServerConfig() *ServerConfig {
 		RateLimitRPS:        getEnvInt("RATE_LIMIT_RPS", 100),
 		RateLimitBurst:      getEnvInt("RATE_LIMIT_BURST", 50),
 		AuthRateLimitRPS:    getEnvInt("AUTH_RATE_LIMIT_RPS", 10),
-		AuthRateLimitBurst:  getEnvInt("AUTH_RATE_LIMIT_BURST", 5),
+		AuthRateLimitBurst:  getEnvInt("AUTH_RATE_LIMIT_BURST", 10),
 		RequestTimeout:      getEnvDuration("REQUEST_TIMEOUT", 30*time.Second),
 		MaxRequestSize:      getEnv("MAX_REQUEST_SIZE", "10M"),
 		EnableGzip:          getEnvBool("ENABLE_GZIP", true),

--- a/backend/infrastructure/web/middleware.go
+++ b/backend/infrastructure/web/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/financial-planning-calculator/backend/config"
@@ -89,11 +90,16 @@ func SetupMiddleware(e *echo.Echo, cfg *config.ServerConfig) *CustomRateLimiterS
 			})
 		},
 		DenyHandler: func(c echo.Context, identifier string, err error) error {
+			info := rateLimitStore.GetInfo(identifier)
+			retryAfterSec := info.Reset - time.Now().Unix()
+			if retryAfterSec < 0 {
+				retryAfterSec = 0
+			}
 			return c.JSON(http.StatusTooManyRequests, map[string]any{
 				"error":       "Too Many Requests",
 				"message":     "Rate limit exceeded. Please wait before retrying.",
 				"code":        "RATE_LIMIT_EXCEEDED",
-				"retry_after": "60s",
+				"retry_after": fmt.Sprintf("%ds", retryAfterSec),
 			})
 		},
 	}))
@@ -127,7 +133,15 @@ func SetupMiddleware(e *echo.Echo, cfg *config.ServerConfig) *CustomRateLimiterS
 
 // extractIdentifier returns the client IP from common proxy headers or the real IP.
 func extractIdentifier(c echo.Context) (string, error) {
+	// X-Forwarded-For は "client, proxy1, proxy2" 形式で複数IPを含む場合がある。
+	// 最左がオリジナルクライアントIPのため、最初のIPのみを使用する。
+	// Note: このヘッダーはクライアントが偽装可能。信頼できるリバースプロキシがある
+	// 環境では、プロキシが付与する最右IPを使う設計への移行を将来的に検討すること。
 	ip := c.Request().Header.Get("X-Forwarded-For")
+	if ip != "" {
+		parts := strings.Split(ip, ",")
+		ip = strings.TrimSpace(parts[0])
+	}
 	if ip == "" {
 		ip = c.Request().Header.Get("X-Real-IP")
 	}

--- a/backend/infrastructure/web/middleware_test.go
+++ b/backend/infrastructure/web/middleware_test.go
@@ -1,9 +1,12 @@
 package web
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,4 +132,73 @@ func TestSetupMiddleware_RateLimitExceeded(t *testing.T) {
 	}
 
 	assert.True(t, rateLimited, "レート制限が機能していません")
+}
+
+func TestExtractIdentifier_MultipleXForwardedFor(t *testing.T) {
+	// X-Forwarded-For に複数IPが含まれる場合、最初のIPのみが返されることを検証する。
+	tests := []struct {
+		name     string
+		header   string
+		expected string
+	}{
+		{"単一IP", "192.168.1.1", "192.168.1.1"},
+		{"複数IP（スペースあり）", "192.168.1.1, 10.0.0.1, 172.16.0.1", "192.168.1.1"},
+		{"複数IP（スペースなし）", "192.168.1.1,10.0.0.1", "192.168.1.1"},
+		{"前後スペース", "  192.168.1.100  , 10.0.0.1", "192.168.1.100"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("X-Forwarded-For", tt.header)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			identifier, err := extractIdentifier(c)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, identifier)
+		})
+	}
+}
+
+func TestSetupMiddleware_DenyHandler_RetryAfterIsDynamic(t *testing.T) {
+	// DenyHandler が "60s" のハードコードではなく動的な値を返すことを検証する。
+	e := echo.New()
+	cfg := &config.ServerConfig{
+		AllowedOrigins: []string{"http://localhost:3000"},
+		CORSMaxAge:     86400,
+		RateLimitRPS:   1,
+		RateLimitBurst: 1,
+		RequestTimeout: 30 * time.Second,
+		MaxRequestSize: "10M",
+	}
+	SetupMiddleware(e, cfg)
+	e.GET("/test", func(c echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
+
+	clientIP := fmt.Sprintf("test-retry-dynamic-%d", time.Now().UnixNano())
+	var retryAfter string
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("X-Forwarded-For", clientIP)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			var body map[string]any
+			json.Unmarshal(rec.Body.Bytes(), &body) //nolint:errcheck
+			retryAfter, _ = body["retry_after"].(string)
+			break
+		}
+	}
+
+	assert.NotEmpty(t, retryAfter, "retry_after フィールドが存在しない")
+	// ハードコード "60s" ではないことを確認
+	assert.NotEqual(t, "60s", retryAfter, "retry_after がハードコードされた '60s' のままです")
+	// "<数値>s" 形式で、0以上180秒以下であること（ウィンドウ=3分）
+	secStr := strings.TrimSuffix(retryAfter, "s")
+	secs, err := strconv.Atoi(secStr)
+	assert.NoError(t, err, "retry_after の秒数をパースできない: %s", retryAfter)
+	assert.GreaterOrEqual(t, secs, 0)
+	assert.LessOrEqual(t, secs, 180)
 }


### PR DESCRIPTION
## Summary

- `AUTH_RATE_LIMIT_BURST` のデフォルト値を 5→10 に緩和し、正規ユーザーの誤入力・再送信によるロックアウトを防ぐ
- 一般 API の `DenyHandler` で `retry_after` を `"60s"` のハードコードから実際のウィンドウリセット時刻の動的計算に変更（認証 API と方式を統一）
- `extractIdentifier` で `X-Forwarded-For: a, b, c` 形式から最初の IP（オリジナルクライアント IP）のみを抽出するよう修正

## Test plan

- [x] `go build ./...` でコンパイルエラーなし
- [x] `go test ./infrastructure/web/... -v` で既存テスト + 新規テスト（`TestExtractIdentifier_MultipleXForwardedFor`、`TestSetupMiddleware_DenyHandler_RetryAfterIsDynamic`）が全て PASS

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)