### PR TITLE
feat(backend): TRUSTED_PROXY_COUNTによるX-Forwarded-For安全解析 #236

### DIFF
--- a/backend/config/server.go
+++ b/backend/config/server.go
@@ -17,6 +17,7 @@ type ServerConfig struct {
 	RateLimitBurst      int
 	AuthRateLimitRPS    int
 	AuthRateLimitBurst  int
+	TrustedProxyCount   int // 信頼済みプロキシ段数（右からN個のIPを除外して識別子を取得）
 	RequestTimeout      time.Duration
 	MaxRequestSize      string
 	EnableGzip          bool
@@ -79,6 +80,7 @@ func LoadServerConfig() *ServerConfig {
 		RateLimitBurst:      getEnvInt("RATE_LIMIT_BURST", 50),
 		AuthRateLimitRPS:    getEnvInt("AUTH_RATE_LIMIT_RPS", 10),
 		AuthRateLimitBurst:  getEnvInt("AUTH_RATE_LIMIT_BURST", 10),
+		TrustedProxyCount:   getEnvInt("TRUSTED_PROXY_COUNT", 1),
 		RequestTimeout:      getEnvDuration("REQUEST_TIMEOUT", 30*time.Second),
 		MaxRequestSize:      getEnv("MAX_REQUEST_SIZE", "10M"),
 		EnableGzip:          getEnvBool("ENABLE_GZIP", true),

--- a/backend/infrastructure/web/middleware.go
+++ b/backend/infrastructure/web/middleware.go
@@ -69,6 +69,7 @@ func SetupMiddleware(e *echo.Echo, cfg *config.ServerConfig) *CustomRateLimiterS
 	e.Use(middleware.BodyLimit(cfg.MaxRequestSize))
 
 	// Rate limiting - per-IP API request throttling (custom store for /api/rate-limit/status)
+	extractIdentifier := newIdentifierExtractor(cfg.TrustedProxyCount)
 	rateLimitStore := NewCustomRateLimiterStore(
 		float64(cfg.RateLimitRPS),
 		cfg.RateLimitBurst,
@@ -105,7 +106,7 @@ func SetupMiddleware(e *echo.Echo, cfg *config.ServerConfig) *CustomRateLimiterS
 	}))
 
 	// X-RateLimit-* response headers
-	e.Use(RateLimitHeaderMiddleware(rateLimitStore))
+	e.Use(RateLimitHeaderMiddleware(rateLimitStore, extractIdentifier))
 
 	// タイムアウト設定（SSEエンドポイントは除外）
 	e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
@@ -131,31 +132,47 @@ func SetupMiddleware(e *echo.Echo, cfg *config.ServerConfig) *CustomRateLimiterS
 	return rateLimitStore
 }
 
-// extractIdentifier returns the client IP from common proxy headers or the real IP.
-func extractIdentifier(c echo.Context) (string, error) {
-	// X-Forwarded-For は "client, proxy1, proxy2" 形式で複数IPを含む場合がある。
-	// 最左がオリジナルクライアントIPのため、最初のIPのみを使用する。
-	// Note: このヘッダーはクライアントが偽装可能。信頼できるリバースプロキシがある
-	// 環境では、プロキシが付与する最右IPを使う設計への移行を将来的に検討すること。
-	ip := c.Request().Header.Get("X-Forwarded-For")
-	if ip != "" {
-		parts := strings.Split(ip, ",")
-		ip = strings.TrimSpace(parts[0])
+// newIdentifierExtractor returns an IdentifierExtractor that resolves the client IP
+// by trusting trustedProxyCount proxies on the right side of X-Forwarded-For.
+//
+// X-Forwarded-For の構造:
+//
+//	203.0.113.5, 10.0.0.1, 54.0.0.1
+//	^^^^^^^^^^^  ^^^^^^^^^  ^^^^^^^^^
+//	クライアント   内部proxy   Railway LB（信頼済み）
+//
+// trustedProxyCount=1 の場合、右から1つ（Railway LB）を除いた最右の値を使用。
+// trustedProxyCount=0 の場合、最左のIPを使用（ローカル開発互換だが偽装可能）。
+func newIdentifierExtractor(trustedProxyCount int) func(echo.Context) (string, error) {
+	return func(c echo.Context) (string, error) {
+		xff := c.Request().Header.Get("X-Forwarded-For")
+		if xff != "" {
+			parts := strings.Split(xff, ",")
+			if trustedProxyCount == 0 {
+				// プロキシを信頼しない場合は最左IP（ローカル開発互換。偽装可能なため本番では非推奨）
+				return strings.TrimSpace(parts[0]), nil
+			}
+			// 右からtrustedProxyCount個を除外し、残りの最右を使用
+			targetIdx := len(parts) - 1 - trustedProxyCount
+			if targetIdx < 0 {
+				targetIdx = 0
+			}
+			return strings.TrimSpace(parts[targetIdx]), nil
+		}
+
+		if ip := c.Request().Header.Get("X-Real-IP"); ip != "" {
+			return ip, nil
+		}
+
+		return c.RealIP(), nil
 	}
-	if ip == "" {
-		ip = c.Request().Header.Get("X-Real-IP")
-	}
-	if ip == "" {
-		ip = c.RealIP()
-	}
-	return ip, nil
 }
 
 // RateLimitHeaderMiddleware attaches X-RateLimit-{Limit,Remaining,Reset} headers to every response.
-func RateLimitHeaderMiddleware(store *CustomRateLimiterStore) echo.MiddlewareFunc {
+func RateLimitHeaderMiddleware(store *CustomRateLimiterStore, extractor func(echo.Context) (string, error)) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			identifier, _ := extractIdentifier(c)
+			identifier, _ := extractor(c)
 			info := store.GetInfo(identifier)
 
 			h := c.Response().Header()
@@ -176,10 +193,11 @@ func AuthRateLimiterMiddleware(cfg *config.ServerConfig) echo.MiddlewareFunc {
 		cfg.AuthRateLimitBurst,
 		5*time.Minute,
 	)
+	extractor := newIdentifierExtractor(cfg.TrustedProxyCount)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			identifier, err := extractIdentifier(c)
+			identifier, err := extractor(c)
 			if err != nil {
 				return c.JSON(http.StatusInternalServerError, map[string]any{
 					"error":   "Internal Server Error",

--- a/backend/infrastructure/web/middleware_test.go
+++ b/backend/infrastructure/web/middleware_test.go
@@ -93,6 +93,92 @@ func TestSetupMiddleware_RateLimiter(t *testing.T) {
 	})
 }
 
+func TestNewIdentifierExtractor(t *testing.T) {
+	tests := []struct {
+		name              string
+		trustedProxyCount int
+		xForwardedFor     string
+		xRealIP           string
+		remoteAddr        string
+		want              string
+	}{
+		{
+			name:              "TRUSTED_PROXY_COUNT=1: 右から1つ除外して最右を使用",
+			trustedProxyCount: 1,
+			xForwardedFor:     "203.0.113.5, 10.0.0.1, 54.0.0.1",
+			want:              "10.0.0.1",
+		},
+		{
+			name:              "TRUSTED_PROXY_COUNT=1: XFFが2エントリ（クライアント+LB）",
+			trustedProxyCount: 1,
+			xForwardedFor:     "203.0.113.5, 54.0.0.1",
+			want:              "203.0.113.5",
+		},
+		{
+			name:              "TRUSTED_PROXY_COUNT=0: 最左IPを使用（ローカル開発互換）",
+			trustedProxyCount: 0,
+			xForwardedFor:     "203.0.113.5, 10.0.0.1, 54.0.0.1",
+			want:              "203.0.113.5",
+		},
+		{
+			name:              "TRUSTED_PROXY_COUNT=1: XFFが単一エントリ（プロキシ数超過）",
+			trustedProxyCount: 1,
+			xForwardedFor:     "203.0.113.5",
+			want:              "203.0.113.5", // targetIdx<0 → 0に補正
+		},
+		{
+			name:              "TRUSTED_PROXY_COUNT=2: 右から2つ除外",
+			trustedProxyCount: 2,
+			xForwardedFor:     "203.0.113.5, 10.0.0.1, 54.0.0.1",
+			want:              "203.0.113.5",
+		},
+		{
+			name:              "XFFなし: X-Real-IPにフォールバック",
+			trustedProxyCount: 1,
+			xRealIP:           "203.0.113.5",
+			remoteAddr:        "127.0.0.1:12345",
+			want:              "203.0.113.5",
+		},
+		{
+			name:              "XFF・X-Real-IPなし: RemoteAddrにフォールバック",
+			trustedProxyCount: 1,
+			remoteAddr:        "203.0.113.5:12345",
+			want:              "203.0.113.5",
+		},
+		{
+			name:              "攻撃シナリオ: 攻撃者が先頭にIPを偽装してもTRUSTED_PROXY_COUNT=1で無効化",
+			trustedProxyCount: 1,
+			// 攻撃者が1.2.3.4を偽装、Railway LBが54.0.0.1を追記
+			xForwardedFor: "1.2.3.4, 203.0.113.5, 54.0.0.1",
+			want:          "203.0.113.5", // 本物のクライアントIP
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.xForwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", tt.xForwardedFor)
+			}
+			if tt.xRealIP != "" {
+				req.Header.Set("X-Real-IP", tt.xRealIP)
+			}
+			if tt.remoteAddr != "" {
+				req.RemoteAddr = tt.remoteAddr
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			extractor := newIdentifierExtractor(tt.trustedProxyCount)
+			got, err := extractor(c)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSetupMiddleware_RateLimitExceeded(t *testing.T) {
 	e := echo.New()
 	cfg := &config.ServerConfig{
@@ -132,33 +218,6 @@ func TestSetupMiddleware_RateLimitExceeded(t *testing.T) {
 	}
 
 	assert.True(t, rateLimited, "レート制限が機能していません")
-}
-
-func TestExtractIdentifier_MultipleXForwardedFor(t *testing.T) {
-	// X-Forwarded-For に複数IPが含まれる場合、最初のIPのみが返されることを検証する。
-	tests := []struct {
-		name     string
-		header   string
-		expected string
-	}{
-		{"単一IP", "192.168.1.1", "192.168.1.1"},
-		{"複数IP（スペースあり）", "192.168.1.1, 10.0.0.1, 172.16.0.1", "192.168.1.1"},
-		{"複数IP（スペースなし）", "192.168.1.1,10.0.0.1", "192.168.1.1"},
-		{"前後スペース", "  192.168.1.100  , 10.0.0.1", "192.168.1.100"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			e := echo.New()
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			req.Header.Set("X-Forwarded-For", tt.header)
-			rec := httptest.NewRecorder()
-			c := e.NewContext(req, rec)
-
-			identifier, err := extractIdentifier(c)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, identifier)
-		})
-	}
 }
 
 func TestSetupMiddleware_DenyHandler_RetryAfterIsDynamic(t *testing.T) {

--- a/backend/infrastructure/web/routes.go
+++ b/backend/infrastructure/web/routes.go
@@ -53,7 +53,7 @@ func SetupRoutes(e *echo.Echo, controllers *Controllers, deps *ServerDependencie
 	api.GET("/ready", APIReadinessHandler(deps))
 
 	// レートリミットステータスエンドポイント（認証不要）
-	api.GET("/rate-limit/status", RateLimitStatusHandler(rateLimitStore))
+	api.GET("/rate-limit/status", RateLimitStatusHandler(rateLimitStore, newIdentifierExtractor(deps.ServerConfig.TrustedProxyCount)))
 
 	// 認証レートリミッターミドルウェア（ブルートフォース対策）
 	authRateLimiter := AuthRateLimiterMiddleware(deps.ServerConfig)
@@ -278,9 +278,9 @@ func APIInfoHandler(c echo.Context) error {
 //	  "reset":     1739865600,
 //	  "reset_at":  "2026-02-18T15:00:00Z"
 //	}
-func RateLimitStatusHandler(store *CustomRateLimiterStore) echo.HandlerFunc {
+func RateLimitStatusHandler(store *CustomRateLimiterStore, extractor func(echo.Context) (string, error)) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		identifier, _ := extractIdentifier(c)
+		identifier, _ := extractor(c)
 		info := store.GetInfo(identifier)
 		return c.JSON(http.StatusOK, info)
 	}

--- a/backend/infrastructure/web/routes_test.go
+++ b/backend/infrastructure/web/routes_test.go
@@ -99,7 +99,7 @@ func TestRateLimitStatusHandler(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	handler := RateLimitStatusHandler(store)
+	handler := RateLimitStatusHandler(store, newIdentifierExtractor(0))
 	err := handler(c)
 
 	assert.NoError(t, err)
@@ -123,7 +123,7 @@ func TestRateLimitStatusHandler_RemainingDecreases(t *testing.T) {
 		req.RemoteAddr = ip + ":1234"
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
-		handler := RateLimitStatusHandler(store)
+		handler := RateLimitStatusHandler(store, newIdentifierExtractor(0))
 		handler(c) //nolint:errcheck
 
 		var info RateLimitInfo


### PR DESCRIPTION
## Summary

- `TRUSTED_PROXY_COUNT` 環境変数（デフォルト: 1）を追加し、信頼済みプロキシ段数を設定可能に
- `extractIdentifier()` を `newIdentifierExtractor(n int)` クロージャに変更
  - `X-Forwarded-For` を右からN個除外した最右のIPを識別子として使用
  - `TRUSTED_PROXY_COUNT=0` でローカル開発互換（最左IP）の挙動を維持
- `RateLimitHeaderMiddleware` / `RateLimitStatusHandler` のシグネチャにextractorを追加し、全箇所で同一のextractorを共有

## 攻撃シナリオの修正

```
# 修正前: 最左IP（偽装可能）をそのまま使用
X-Forwarded-For: 1.2.3.4（偽装）, 203.0.113.5（本物）, 54.0.0.1（Railway LB）
→ 1.2.3.4 が識別子となりレート制限を回避可能

# 修正後: TRUSTED_PROXY_COUNT=1 で右から1つ除外した最右を使用
→ 203.0.113.5（本物のクライアントIP）が識別子となり回避不可能
```

## Test plan

- [x] `go build ./...` でコンパイルエラーなし
- [x] `TestNewIdentifierExtractor` (8ケース): 攻撃シナリオ・プロキシ段数超過・各フォールバックを網羅
- [x] `go test ./infrastructure/web/...` で既存テストも全てPASS

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)