### PR TITLE
fix(ci): E2EテストのNEXT_PUBLIC_API_URLから重複する/apiを削除

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Start frontend server
         working-directory: ./frontend
         env:
-          NEXT_PUBLIC_API_URL: http://localhost:8080/api
+          NEXT_PUBLIC_API_URL: http://localhost:8080
           NODE_ENV: production
         run: |
           npm run build


### PR DESCRIPTION
## Summary

- `e2e-tests.yml` の `NEXT_PUBLIC_API_URL` から末尾の `/api` を削除

## 原因

`next.config.js` の rewrite 設定：

```js
source: '/api/:path*',
destination: `${process.env.NEXT_PUBLIC_API_URL}/api/:path*`
```

`NEXT_PUBLIC_API_URL=http://localhost:8080/api` の場合、`/api/auth/login` のリクエストが `http://localhost:8080/api/api/auth/login` に転送されて 404 になっていた。

ログインページに「リソースが見つかりません」と表示されてログインが失敗し、E2E の `login-test.spec.ts` が 30 秒タイムアウトしていた。

## Test plan

- [ ] E2E Tests: `login-test.spec.ts` がタイムアウトせずパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)