### PR TITLE
fix(ci): GoバージョンをCI/CDとgo.modで統一（go-version-file方式に移行）

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -2,19 +2,13 @@
 name: 'Composite Go Setup'
 description: 'Checks out code, sets up Go, caches modules, and installs dependencies'
 
-inputs:
-  go-version:
-    required: true
-    type: string
-    description: "Go version to use"
-
 runs:
   using: "composite"
   steps:
-    - name: Set up Go ${{ inputs.go-version }}
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ inputs.go-version }}
+        go-version-file: 'backend/go.mod'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -22,9 +16,9 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ inputs.go-version }}-${{ hashFiles('backend/go.sum') }}
+        key: ${{ runner.os }}-go-${{ hashFiles('backend/go.mod') }}-${{ hashFiles('backend/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ inputs.go-version }}-
+          ${{ runner.os }}-go-${{ hashFiles('backend/go.mod') }}-
           ${{ runner.os }}-go-
 
     - name: Install dependencies

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,8 +67,6 @@ jobs:
 
       - name: Setup Go Environment
         uses: ./.github/actions/setup-go
-        with:
-          go-version: '1.21'
 
       - name: Ensure go.mod/go.sum are tidy
         working-directory: ./backend

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,6 @@ jobs:
               uses: actions/checkout@v4
             - name: Setup Go Environment
               uses: ./.github/actions/setup-go
-              with:
-                go-version: '1.21'
             - name: Go Mod Tidy
               working-directory: ./backend
               run: go mod tidy

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Go Environment
         uses: ./.github/actions/setup-go
-        with:
-          go-version: '1.21'
       
       - name: Go Mod Tidy
         working-directory: ./backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   test-backend:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.21']
 
     services:
       redis:
@@ -28,19 +25,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Go Environment
         uses: ./.github/actions/setup-go
-        with:
-          go-version: ${{ matrix.go-version }}
-      
+
       - name: Build
         working-directory: ./backend
         run: go build -v ./...
-      
+
       - name: Run tests with coverage
         working-directory: ./backend
         run: go test -v -race -timeout 30s -coverprofile=coverage.out -covermode=atomic ./...
-      
+
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.21'
         uses: codecov/codecov-action@v4
         with:
           file: ./backend/coverage.out
@@ -50,7 +44,7 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,7 +53,7 @@ jobs:
         with:
           node-version: '20'
           working-directory: './frontend'
-      
+
       - name: Security audit
         working-directory: ./frontend
         run: npm audit --audit-level=high
@@ -67,11 +61,11 @@ jobs:
       - name: Build
         working-directory: ./frontend
         run: npm run build
-      
+
       - name: Run frontend tests
         working-directory: ./frontend
         run: npm test -- --coverage --watchAll=false
-      
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## 概要

Issue #242 の対応。GitHub Actions の Go バージョンが `1.21` 固定になっていたが、`go.mod` の `go 1.24.0` との乖離を解消する。

## 変更内容

- `.github/actions/setup-go/action.yml`: `go-version` input を廃止し `go-version-file: 'backend/go.mod'` 方式に変更
- 全ワークフローの `setup-go` 呼び出しから `go-version: '1.21'` の指定を削除
- `test.yml`: 単一バージョンしかテストしていなかった無意味な matrix 戦略を削除

## 対象ファイル

| ファイル | 変更内容 |
|---|---|
| `.github/actions/setup-go/action.yml` | `go-version-file: 'backend/go.mod'` に変更 |
| `.github/workflows/test.yml` | matrix 廃止・`go-version` 指定削除 |
| `.github/workflows/lint.yml` | `go-version: '1.21'` 削除 |
| `.github/workflows/pr-check.yml` | `go-version: '1.21'` 削除 |
| `.github/workflows/e2e-tests.yml` | `go-version: '1.21'` 削除 |

## 効果

- `backend/go.mod` が Single Source of Truth となり、将来のGoアップグレード時も `go.mod` の変更だけで全CI/CDに反映される
- CI グリーン = 本番ビルド可能 の信頼性が担保される

## チェックリスト

- [x] 全ワークフローの Go バージョンが `go.mod` と一致していること
- [x] `go-version-file` 方式への移行完了
- [ ] CI がすべてグリーンであること（PR後に確認）

Closes #242